### PR TITLE
Add support for filtering the output and cli options

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,16 @@ The code reads data from stdin, aggregates per KR and outputs the result.
 Example:
 
 ```
-# cat okr-report1.md okr-report2.md | okra | less
+# cat okr-report1.md okr-report2.md | okra cat | less
 ```
 
 If there are warnings that are not expected (i.e not about the "OKR updates" section), they should be manually resolved. There's also a script that handles some common formatting issues by fixing indents, bulletpoints etc (fmt.sh). To use it:
 
+```
+# cat okr-report1.md okr-report2.md | ./fmt.sh | okra cat | less
+```
 
-```
-# cat okr-report1.md okr-report2.md | ./fmt.sh | okra | less
-```
+Several options are available for modifying the output format, see `okra cat --help` for details. Sections can optionally be ignored and removed from the final output ("OKR updates" is ignored by default).
 
 ## Report format
 
@@ -40,7 +41,7 @@ The tool will attempt to group data by project, objective and KR if these match.
 
 ## Fixing warnings
 
-Warnings will be shown for sections that are unparsable for some reason. This can be because it doesn't follow the defined format (e.g. it is valid, but something else) or it can have accidental formatting errors. You should always check all warnings to make sure that the returned result is correct.
+Exceptions with warnings will be raised if the tool is unable to locate the engineer time in a section. This can be because it doesn't follow the defined format (e.g. it is valid, but something else) or it can have accidental formatting errors. You should always resolve warnings to make sure that the returned result is correct.
 
 Some issues that cause warnings:
 

--- a/bin/dune
+++ b/bin/dune
@@ -1,4 +1,4 @@
 (executable
  (name main)
  (public_name okra)
- (libraries okra))
+ (libraries okra cmdliner))

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -17,37 +17,92 @@
 
 open Okra
 
-let () =
-  let md = Omd.of_channel stdin in
-  let okrs = Okra.process md in
+(** [report_team_md okrs] outputs a team report to stdout. 
 
-  (*Hashtbl.iter (fun _ v ->
-    print_okrs v) store.okr_ht*)
+[ignore_sections] ignores a list of subsections in the report. By default this
+is set to "OKR updates".
+
+[include_krs] only includes this list of KR IDs. Note that this will ignore
+empty KR IDs or KRs marked as "NEW KR" unless specified in the list. If the
+list is empty, all KRs are returned.
+
+When [show_time_calc] is set, an extra line will be added to the output each
+time the same entry is included in the report with a sum at the end. This is
+useful for showing the intermediate steps when aggreating multiple reports that
+contain the same KR.
+
+Example output with [show_time_calc] enabled:
+
+- This is a KR (KR ID)
+  + @engineer1 (1 day), @engineer2 (1 day)
+  + @engineer1 (1 day)
+  = @engineer1 (2 days), @engineer2 (1 day)
+  - Work item
+  ...
+
+[show_time] shows the time entries
+[show_engineers] shows the list of engineers
+
+*)
+let report_team_md ?ignore_sections:(ignore_sections=["OKR updates"])
+		   ?include_krs:(include_krs=[])
+		   ?show_time:(show_time=true)
+  		   ?show_time_calc:(show_time_calc=true)
+                   ?show_engineers:(show_engineers=true)
+		   okrs =
   let v = List.map Okra.of_weekly (List.of_seq (Hashtbl.to_seq_values okrs)) in
+  let uppercase_include_krs = (List.map String.uppercase_ascii include_krs) in
+  let uppercase_ignore_sections = (List.map String.uppercase_ascii ignore_sections) in
   let c_project = ref "" in
   let c_objective = ref "" in
   let c_kr_id = ref "" in
   let c_kr_title = ref "" in
   List.iter
     (fun e ->
-      if e.project <> !c_project then (
-        Printf.printf "\n# %s\n" e.project;
-        c_project := e.project)
-      else ();
-      if e.objective <> !c_objective then (
-        Printf.printf "\n## %s\n" e.objective;
-        c_objective := e.objective)
-      else ();
-      if e.kr_id <> !c_kr_id || e.kr_title <> !c_kr_title then (
-        Printf.printf "\n- %s (%s)\n" e.kr_title e.kr_id;
-        c_kr_title := e.kr_title;
-        c_kr_id := e.kr_id)
-      else ();
-      List.iter (fun s -> Printf.printf "    - + %s" s) e.time_entries;
-      Printf.printf "    - = ";
-      Hashtbl.iter
-        (fun s v -> Printf.printf "@%s (%.2f days) " s v)
-        e.time_per_engineer;
-      Printf.printf "\n";
-      List.iter (fun s -> Printf.printf "    - %s" s) e.work)
+      (* only proceed if include_krs is empty or has a match, and ignore_sections is empty or without match *)
+      if ((List.length include_krs == 0 || List.mem e.kr_id uppercase_include_krs)) &&
+	 ((List.length ignore_sections == 0 || not (List.mem (String.uppercase_ascii e.project) uppercase_ignore_sections))) then (
+	      if e.project <> !c_project then (
+		Printf.printf "\n# %s\n" e.project;
+		c_project := e.project)
+	      else ();
+	      if e.objective <> !c_objective then (
+		Printf.printf "\n## %s\n" e.objective;
+		c_objective := e.objective)
+	      else ();
+	      if e.kr_id <> !c_kr_id || e.kr_title <> !c_kr_title then (
+		Printf.printf "\n- %s (%s)\n" e.kr_title e.kr_id;
+		c_kr_title := e.kr_title;
+		c_kr_id := e.kr_id)
+	      else ();
+	      if show_engineers then (
+		      if show_time then (
+			      if show_time_calc then ( (* show time calc + engineers *)
+				      List.iter (fun s -> Printf.printf "    - + %s" s) e.time_entries;
+				      Printf.printf "    - = ";
+				      Hashtbl.iter
+					(fun s v -> Printf.printf "@%s (%.2f days) " s v)
+					e.time_per_engineer;
+				      Printf.printf "\n")
+			      else ( (* show total time for each engineer *)
+				      Printf.printf "    - ";
+				      Hashtbl.iter
+					(fun s v -> Printf.printf "@%s (%.2f days) " s v)
+					e.time_per_engineer;
+				      Printf.printf "\n"))
+		      else ( (* only show engineers, no time *)
+			      Printf.printf "    - ";
+			      Hashtbl.iter
+				(fun s _ -> Printf.printf "@%s " s)
+				e.time_per_engineer;
+			      Printf.printf "\n"))
+	      else (); (* don't show time or engineers *)
+	      List.iter (fun s -> Printf.printf "    - %s" s) e.work)
+      else () (* skip this KR *)
+    )
     (List.sort Okra.compare v)
+
+let () =
+  let md = Omd.of_channel stdin in
+  let okrs = Okra.process md in
+  report_team_md okrs

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1,5 +1,5 @@
 (*
- * Copyright (c) 2021 Magnus Skjegstad
+ * Copyright (c) 2021 Magnus Skjegstad <magnus@skjegstad.com>
  * Copyright (c) 2021 Thomas Gazagnaire <thomas@gazagnaire.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
@@ -15,94 +15,117 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Okra
+open Cmdliner
 
-(** [report_team_md okrs] outputs a team report to stdout. 
+type cat_conf = {
+  show_time : bool;
+  show_time_calc : bool;
+  show_engineers : bool;
+  ignore_sections : string list;
+  include_krs : string list;
+}
 
-[ignore_sections] ignores a list of subsections in the report. By default this
-is set to "OKR updates".
+type okra_conf = Cat of cat_conf
 
-[include_krs] only includes this list of KR IDs. Note that this will ignore
-empty KR IDs or KRs marked as "NEW KR" unless specified in the list. If the
-list is empty, all KRs are returned.
+let run cmds =
+  match cmds with
+  | Cat conf ->
+      let md = Omd.of_channel stdin in
+      let okrs = Okra.process ~ignore_sections:conf.ignore_sections md in
+      Reports.report_team_md ~show_time:conf.show_time
+        ~show_time_calc:conf.show_time_calc ~show_engineers:conf.show_engineers
+        ~include_krs:conf.include_krs okrs
 
-When [show_time_calc] is set, an extra line will be added to the output each
-time the same entry is included in the report with a sum at the end. This is
-useful for showing the intermediate steps when aggreating multiple reports that
-contain the same KR.
+let show_time_term =
+  let info =
+    Arg.info [ "show-time" ] ~doc:"Include engineering time in output"
+  in
+  Arg.value (Arg.opt Arg.bool true info)
 
-Example output with [show_time_calc] enabled:
+let show_time_calc_term =
+  let info =
+    Arg.info [ "show-time-calc" ]
+      ~doc:
+        "Include intermediate time calculations in output, showing each time \
+         entry found with a sum at the end. This is useful for debugging when \
+         aggregating reports for multiple weeks."
+  in
+  Arg.value (Arg.opt Arg.bool true info)
 
-- This is a KR (KR ID)
-  + @engineer1 (1 day), @engineer2 (1 day)
-  + @engineer1 (1 day)
-  = @engineer1 (2 days), @engineer2 (1 day)
-  - Work item
-  ...
+let show_engineers_term =
+  let info =
+    Arg.info [ "show-engineers" ] ~doc:"Include a list of engineers per KR"
+  in
+  Arg.value (Arg.opt Arg.bool true info)
 
-[show_time] shows the time entries
-[show_engineers] shows the list of engineers
+let ignore_sections_term =
+  let info =
+    Arg.info [ "ignore-sections" ]
+      ~doc:
+        "If non-empty, ignore everyhing under these sections (titles) from the \
+         report"
+  in
+  Arg.value (Arg.opt (Arg.list Arg.string) [ "OKR updates" ] info)
 
-*)
-let report_team_md ?ignore_sections:(ignore_sections=["OKR updates"])
-		   ?include_krs:(include_krs=[])
-		   ?show_time:(show_time=true)
-  		   ?show_time_calc:(show_time_calc=true)
-                   ?show_engineers:(show_engineers=true)
-		   okrs =
-  let v = List.map Okra.of_weekly (List.of_seq (Hashtbl.to_seq_values okrs)) in
-  let uppercase_include_krs = (List.map String.uppercase_ascii include_krs) in
-  let uppercase_ignore_sections = (List.map String.uppercase_ascii ignore_sections) in
-  let c_project = ref "" in
-  let c_objective = ref "" in
-  let c_kr_id = ref "" in
-  let c_kr_title = ref "" in
-  List.iter
-    (fun e ->
-      (* only proceed if include_krs is empty or has a match, and ignore_sections is empty or without match *)
-      if ((List.length include_krs == 0 || List.mem e.kr_id uppercase_include_krs)) &&
-	 ((List.length ignore_sections == 0 || not (List.mem (String.uppercase_ascii e.project) uppercase_ignore_sections))) then (
-	      if e.project <> !c_project then (
-		Printf.printf "\n# %s\n" e.project;
-		c_project := e.project)
-	      else ();
-	      if e.objective <> !c_objective then (
-		Printf.printf "\n## %s\n" e.objective;
-		c_objective := e.objective)
-	      else ();
-	      if e.kr_id <> !c_kr_id || e.kr_title <> !c_kr_title then (
-		Printf.printf "\n- %s (%s)\n" e.kr_title e.kr_id;
-		c_kr_title := e.kr_title;
-		c_kr_id := e.kr_id)
-	      else ();
-	      if show_engineers then (
-		      if show_time then (
-			      if show_time_calc then ( (* show time calc + engineers *)
-				      List.iter (fun s -> Printf.printf "    - + %s" s) e.time_entries;
-				      Printf.printf "    - = ";
-				      Hashtbl.iter
-					(fun s v -> Printf.printf "@%s (%.2f days) " s v)
-					e.time_per_engineer;
-				      Printf.printf "\n")
-			      else ( (* show total time for each engineer *)
-				      Printf.printf "    - ";
-				      Hashtbl.iter
-					(fun s v -> Printf.printf "@%s (%.2f days) " s v)
-					e.time_per_engineer;
-				      Printf.printf "\n"))
-		      else ( (* only show engineers, no time *)
-			      Printf.printf "    - ";
-			      Hashtbl.iter
-				(fun s _ -> Printf.printf "@%s " s)
-				e.time_per_engineer;
-			      Printf.printf "\n"))
-	      else (); (* don't show time or engineers *)
-	      List.iter (fun s -> Printf.printf "    - %s" s) e.work)
-      else () (* skip this KR *)
-    )
-    (List.sort Okra.compare v)
+let include_krs_term =
+  let info =
+    Arg.info [ "include-krs" ]
+      ~doc:"If non-empty, only include this list of KR IDs in the output."
+  in
+  Arg.value (Arg.opt (Arg.list Arg.string) [] info)
+
+let cat_term =
+  let cat show_time show_time_calc show_engineers include_krs ignore_sections =
+    Cat
+      {
+        show_time;
+        show_time_calc;
+        show_engineers;
+        include_krs;
+        ignore_sections;
+      }
+  in
+  Term.(
+    const cat
+    $ show_time_term
+    $ show_time_calc_term
+    $ show_engineers_term
+    $ include_krs_term
+    $ ignore_sections_term)
+
+let cat_cmd =
+  let info =
+    Term.info "cat" ~doc:"parse and concatenate reports"
+      ~man:
+        [
+          `S Manpage.s_description;
+          `P
+            "Parses one or more OKR reports and outputs a report aggregated \
+             per KR. See below for options for modifying the output format.";
+        ]
+  in
+  (cat_term, info)
+
+let root_term = Term.ret (Term.const (`Help (`Pager, None)))
+
+let root_cmd =
+  let info =
+    Term.info "okra" ~doc:"a tool to parse and process OKR reports"
+      ~man:
+        [
+          `S Manpage.s_description;
+          `P
+            "This tool can be used to aggregate and process OKR reports in a \
+             specific format. See project README for details.";
+        ]
+  in
+  (root_term, info)
 
 let () =
-  let md = Omd.of_channel stdin in
-  let okrs = Okra.process md in
-  report_team_md okrs
+  let conf =
+    match Term.eval_choice root_cmd [ cat_cmd ] with
+    | `Error _ -> exit 1
+    | `Version | `Help -> exit 0
+    | `Ok conf -> conf
+  in
+  run conf

--- a/bin/reports.ml
+++ b/bin/reports.ml
@@ -1,0 +1,85 @@
+(*
+ * Copyright (c) 2021 Magnus Skjegstad <magnus@skjegstad.com>
+ * Copyright (c) 2021 Thomas Gazagnaire <thomas@gazagnaire.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+open Okra
+
+(** [report_team_md okrs] outputs a team report to stdout.
+
+    [include_krs] only includes this list of KR IDs. Note that this will ignore
+    empty KR IDs or KRs marked as "NEW KR" unless specified in the list. If the
+    list is empty, all KRs are returned.
+
+    When [show_time_calc] is set, an extra line will be added to the output each
+    time the same entry is included in the report with a sum at the end. This is
+    useful for showing the intermediate steps when aggreating multiple reports
+    that contain the same KR.
+
+    [show_time] shows the time entries [show_engineers] shows the list of
+    engineers *)
+let report_team_md ?(include_krs = []) ?(show_time = true)
+    ?(show_time_calc = true) ?(show_engineers = true) okrs =
+  let v = List.map Okra.of_weekly (List.of_seq (Hashtbl.to_seq_values okrs)) in
+  let uppercase_include_krs = List.map String.uppercase_ascii include_krs in
+  let c_project = ref "" in
+  let c_objective = ref "" in
+  let c_kr_id = ref "" in
+  let c_kr_title = ref "" in
+  List.iter
+    (fun e ->
+      (* only proceed if include_krs is empty or has a match *)
+      if List.length include_krs == 0 || List.mem e.kr_id uppercase_include_krs
+      then (
+        if e.project <> !c_project then (
+          Printf.printf "\n# %s\n" e.project;
+          c_project := e.project)
+        else ();
+        if e.objective <> !c_objective then (
+          Printf.printf "\n## %s\n" e.objective;
+          c_objective := e.objective)
+        else ();
+        if e.kr_id <> !c_kr_id || e.kr_title <> !c_kr_title then (
+          Printf.printf "\n- %s (%s)\n" e.kr_title e.kr_id;
+          c_kr_title := e.kr_title;
+          c_kr_id := e.kr_id)
+        else ();
+        if show_engineers then
+          if show_time then
+            if show_time_calc then (
+              (* show time calc + engineers *)
+              List.iter (fun s -> Printf.printf "    - + %s" s) e.time_entries;
+              Printf.printf "    - = ";
+              Hashtbl.iter
+                (fun s v -> Printf.printf "@%s (%.2f days) " s v)
+                e.time_per_engineer;
+              Printf.printf "\n")
+            else (
+              (* show total time for each engineer *)
+              Printf.printf "    - ";
+              Hashtbl.iter
+                (fun s v -> Printf.printf "@%s (%.2f days) " s v)
+                e.time_per_engineer;
+              Printf.printf "\n")
+          else (
+            (* only show engineers, no time *)
+            Printf.printf "    - ";
+            Hashtbl.iter (fun s _ -> Printf.printf "@%s " s) e.time_per_engineer;
+            Printf.printf "\n")
+        else ();
+        (* don't show time or engineers *)
+        List.iter (fun s -> Printf.printf "    - %s" s) e.work)
+      else () (* skip this KR *))
+    (List.sort Okra.compare v)

--- a/dune-project
+++ b/dune-project
@@ -14,4 +14,5 @@
  (depends
   (ocaml (>= 4.07))
   fmt
+  cmdliner
   (omd (>= 2.0))))

--- a/okra.opam
+++ b/okra.opam
@@ -9,6 +9,7 @@ depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.07"}
   "fmt"
+  "cmdliner"
   "omd" {>= "2.0"}
   "odoc" {with-doc}
 ]

--- a/src/okra.mli
+++ b/src/okra.mli
@@ -17,7 +17,6 @@
 
 exception No_time_found of string
 exception Multiple_time_entries of string
-exception KR_title_id_mismatch of string
 
 type t = {
   counter : int;
@@ -42,5 +41,9 @@ module Weekly : sig
   val filter : t -> string -> t
 end
 
-val process : (string * string) list Omd.block list -> Weekly.table
+val process :
+  ?ignore_sections:string list ->
+  (string * string) list Omd.block list ->
+  Weekly.table
+
 val of_weekly : Weekly.t -> t


### PR DESCRIPTION
This adds support for a new `cat` cli subcommand. By default `okra cat` will work as `okra` did previously. Optionally new options can used for:

- showing/hiding engineering time
- including only a specific set of KR IDs
- ignoring some subsections (by default OKR updates)
- showing/hiding time calculation steps for aggregated reports

The old warnings are now thrown as exceptions, as they should either be resolved or be part of a section that is ignored (such as OKR updates)

(fixes #5 and fixes #7)