### PR TITLE
format weekly activity better

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -1,4 +1,4 @@
 (executable
  (name main)
  (public_name okra)
- (libraries okra cmdliner))
+ (libraries okra cmdliner bos))

--- a/dune-project
+++ b/dune-project
@@ -16,6 +16,7 @@
   (alcotest :with-test)
   fmt
   cmdliner
+  bos
   get-activity
   calendar
   (omd (>= 2.0))))

--- a/okra.opam
+++ b/okra.opam
@@ -31,5 +31,5 @@ build: [
   ]
 ]
 pin-depends: [
-  ["get-activity.dev" "git+https://github.com/patricoferris/get-activity#6d45ea876ffa20c865879cadacadce612ed04e63"]
+  ["get-activity.dev" "git+https://github.com/patricoferris/get-activity#1ef19055b27c46e3fc7e27acfed9ab83bd423d8a"]
 ]

--- a/okra.opam
+++ b/okra.opam
@@ -11,6 +11,7 @@ depends: [
   "alcotest" {with-test}
   "fmt"
   "cmdliner"
+  "bos"
   "get-activity"
   "calendar"
   "omd" {>= "2.0"}

--- a/okra.opam.template
+++ b/okra.opam.template
@@ -1,3 +1,3 @@
 pin-depends: [
-  ["get-activity.dev" "git+https://github.com/patricoferris/get-activity#6d45ea876ffa20c865879cadacadce612ed04e63"]
+  ["get-activity.dev" "git+https://github.com/patricoferris/get-activity#1ef19055b27c46e3fc7e27acfed9ab83bd423d8a"]
 ]

--- a/src/activity.mli
+++ b/src/activity.mli
@@ -14,12 +14,27 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-type t
+type conf
 (** Configuration for get-activity *)
 
-val make : string -> t
+val make_conf : string -> conf
 (** [make token] constructs a new configuration using the [token] *)
 
-val run : Calendar.t -> t -> (string, [ `Msg of string ]) Lwt_result.t
-(** [run cal t] produces a get-activity report for the week and year specified
-    by [cal] using the configuration [t]. *)
+type t
+(** The type for your weekly activity *)
+
+val make : projects:string list -> Get_activity.Contributions.t -> t
+(** [make_activity ~projects activites] builds a new weekly activity *)
+
+val pp : t Fmt.t
+(** [pp ppf activity] formats a weekly activity into a template that needs some
+    editing to get it into the correct format. *)
+
+val run :
+  cal:Calendar.t ->
+  projects:string list ->
+  conf ->
+  (t, [ `Msg of string ]) Lwt_result.t
+(** [run ~cal ~projects conf] produces an activity report for the week and year
+    specified by [cal] using the configuration [conf]. The [projects] should be
+    a list of KRs formatted as [<kr-title> (<kr-id>)] *)

--- a/test/expect/dune
+++ b/test/expect/dune
@@ -1,0 +1,3 @@
+(tests
+ (names test_engineer)
+ (libraries okra))

--- a/test/expect/test_engineer.expected
+++ b/test/expect/test_engineer.expected
@@ -1,0 +1,14 @@
+# Projects
+
+Make okra great (OKRA1)
+
+# Last Week
+
+- Make okra great (OKRA1)
+  - @bactrian (<X> days)
+  - Work Item 1
+
+# Activity (move these items to last week)
+
+ - Fix bug in Okra [#42](https://github.com/bactrian/okra/pull/42)
+ - Fix another bug in Okra [#43](https://github.com/bactrian/okra/pull/43)

--- a/test/expect/test_engineer.ml
+++ b/test/expect/test_engineer.ml
@@ -1,0 +1,50 @@
+(*
+ * Copyright (c) 2021 Patrick Ferris <pf341@patricoferris.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+open Okra
+
+let activity =
+  let open Get_activity.Contributions in
+  let projects = [ "Make okra great (OKRA1)" ] in
+  let items : item list =
+    [
+      {
+        repo = "bactrian/okra";
+        kind = `PR;
+        date = "";
+        title = "Fix bug in Okra";
+        body = "Fixes a bug in Okra";
+        url = "https://github.com/bactrian/okra/pull/42";
+      };
+      {
+        repo = "bactrian/okra";
+        kind = `PR;
+        date = "";
+        title = "Fix another bug in Okra";
+        body = "Fixes another bug in Okra";
+        url = "https://github.com/bactrian/okra/pull/43";
+      };
+    ]
+  in
+  let (activity : item list Repo_map.t) =
+    List.fold_left
+      (fun map item -> Repo_map.add "bactrian/okra" item map)
+      Repo_map.empty [ items ]
+  in
+  let activities = { username = "bactrian"; activity } in
+  Activity.make ~projects activities
+
+let () = Activity.pp Fmt.stdout activity


### PR DESCRIPTION
This PR mainly adds an `Okra.Activity.pp` function to print a weekly activity in a format close to how we want it. The easiest way to see it is in the [`test/expect/test_engineer.expected` output](https://github.com/patricoferris/okra-1/blob/28d88e7beb833a40b19bbbf880afa9a0fe21f585/test/expect/test_engineer.expected). Note this did require some small changes in `get-activity` to expose the `pp_item` function and to get the user associated with the contributions collections from the Github API.

The `~/.okra/conf` file is optional and for now is just read as a list of `<kr-title> (<kr-id>)` strings separated by newlines (there's no check that that is in fact what each line says...). If we find more things that could be added here to customise what Okra does then we could change to something a bit more structured.