### PR TITLE
add formatted configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,17 @@ Some issues that cause warnings:
   - Inconsistent bulletpoint formatting. If switching between different bulletpoint markers (such as +, - and asterisk) in the same list, the parser `omd` can become confused. Fix this by always using `-`.
   - Inconsistent indent. If the indent for bulletpoints is only a space (instead of two or a tab) the parse can be confused. Similarly if it switches between tabs and spaces.
   - The OKR line is not followed by a line of engineer-time, with each name prefixed by '@' -- sometimes the '@' is forgotten.
+
+## Okra Configuration File
+
+You can store a `conf.yaml` file in `~/.okra` to provide the binary with extra information to help writing weekly reports, aggregating across directories etc. You don't need a configuration file, there is a default one (but it isn't particularly useful).
+
+```yaml
+# Projects are used in weekly report generation (optional)
+projects:
+  - "Make okra great (Plat123)"
+# Locations will be used in aggregation across multiple directories (optional)
+locations:
+  - "/path/to/admin/dir1"
+  - "/path/to/admin/dir2"
+```

--- a/bin/conf.ml
+++ b/bin/conf.ml
@@ -16,7 +16,7 @@
 
 type t = { projects : string list; locations : string list }
 
-let default = { projects = []; locations = [] }
+let default = { projects = [ "TODO ADD KR (ID)" ]; locations = [] }
 let conf_err s = Error (`Msg (Fmt.str "Okra Conf Error: %s" s))
 
 let of_yaml yaml =

--- a/bin/conf.ml
+++ b/bin/conf.ml
@@ -1,0 +1,57 @@
+(*
+ * Copyright (c) 2021 Patrick Ferris <pf341@patricoferris.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+type t = { projects : string list; locations : string list }
+
+let default = { projects = []; locations = [] }
+let conf_err s = Error (`Msg (Fmt.str "Okra Conf Error: %s" s))
+
+let of_yaml yaml =
+  let open Rresult in
+  let open Yaml.Util in
+  let map_option f = function
+    | None -> Ok [ "TODO ADD KR (ID)" ]
+    | Some (`A v) -> (
+        try Ok (List.map f v) with Yaml.Util.Value_error s -> conf_err s)
+    | Some _ -> conf_err "Expected a list"
+  in
+  find "projects" yaml >>= map_option to_string_exn >>= fun projects ->
+  find "locations" yaml >>= map_option to_string_exn >>= fun locations ->
+  Ok { projects; locations }
+
+let projects { projects; _ } = projects
+let locations { locations; _ } = locations
+
+let load file =
+  let open Rresult in
+  Bos.OS.File.read (Fpath.v file) >>= fun contents ->
+  Yaml.of_string contents >>= fun yaml -> of_yaml yaml
+
+let home =
+  match Sys.getenv_opt "HOME" with
+  | None -> Fmt.failwith "$HOME is not set!"
+  | Some dir -> dir
+
+let default_okra_file =
+  let ( / ) = Filename.concat in
+  home / ".okra" / "conf.yaml"
+
+open Cmdliner
+
+let cmdliner =
+  Arg.value
+  @@ Arg.opt Arg.file default_okra_file
+  @@ Arg.info ~doc:"Okra configuration file" ~docv:"CONF" [ "conf" ]

--- a/bin/conf.mli
+++ b/bin/conf.mli
@@ -1,0 +1,33 @@
+(*
+ * Copyright (c) 2021 Patrick Ferris <pf341@patricoferris.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+type t
+(** The type for okra configurations *)
+
+val default : t
+(** A default configuration *)
+
+val projects : t -> string list
+(** A user's list of activer projects *)
+
+val locations : t -> string list
+(** A list of locations to use when aggregating reports *)
+
+val load : string -> (t, [ `Msg of string ]) result
+(** [load file] attempts to load a configuration from [file] *)
+
+val cmdliner : string Cmdliner.Term.t
+(** Cmdliner term for configuration file location *)

--- a/bin/dune
+++ b/bin/dune
@@ -1,4 +1,4 @@
 (executable
  (name main)
  (public_name okra)
- (libraries okra cmdliner bos))
+ (libraries okra cmdliner bos yaml))

--- a/dune-project
+++ b/dune-project
@@ -19,4 +19,5 @@
   bos
   get-activity
   calendar
+  (yaml (>= 3.0))
   (omd (>= 2.0))))

--- a/okra.opam
+++ b/okra.opam
@@ -14,6 +14,7 @@ depends: [
   "bos"
   "get-activity"
   "calendar"
+  "yaml" {>= "3.0"}
   "omd" {>= "2.0"}
   "odoc" {with-doc}
 ]

--- a/src/activity.ml
+++ b/src/activity.ml
@@ -61,7 +61,7 @@ let pp_last_week username ppf projects =
 
 let pp_activity ppf activity =
   let open Get_activity.Contributions in
-  let pp_item ppf item = Fmt.pf ppf " - %a" pp_title item in
+  let pp_item ppf item = Fmt.pf ppf "  - %a" pp_title item in
   let bindings = Repo_map.bindings activity in
   let pp_binding ppf (_repo, items) =
     Fmt.pf ppf "%a" Fmt.(list pp_item) items

--- a/test/expect/test_engineer.expected
+++ b/test/expect/test_engineer.expected
@@ -10,5 +10,5 @@ Make okra great (OKRA1)
 
 # Activity (move these items to last week)
 
- - Fix bug in Okra [#42](https://github.com/bactrian/okra/pull/42)
- - Fix another bug in Okra [#43](https://github.com/bactrian/okra/pull/43)
+  - Fix bug in Okra [#42](https://github.com/bactrian/okra/pull/42)
+  - Fix another bug in Okra [#43](https://github.com/bactrian/okra/pull/43)


### PR DESCRIPTION
This PR adds a yaml formatted configuration file (default path is now `~/.okra/conf.yaml`). All of the fields are optional (so is the file itself) with defaults being filled in appropriately. The `locations` field is added (mentioned in #13) but the availability check has not been added, perhaps a default location will end up being the `cwd`.

Another small change was to indent the activities so that moving them to their project is very easy (on VSCode `opt+<arrow>`).