### PR TITLE
format projects as a markdown list

### DIFF
--- a/src/activity.ml
+++ b/src/activity.ml
@@ -86,7 +86,7 @@ let pp ppf { projects; activity = { username; activity } } =
 
 %a
 |}
-    Fmt.(list string)
+    Fmt.(list (fun ppf s -> Fmt.pf ppf "- %s" s))
     projects (pp_last_week username) projects pp_activity activity
 
 let run ~cal ~projects { token } =

--- a/test/expect/test_engineer.expected
+++ b/test/expect/test_engineer.expected
@@ -1,6 +1,6 @@
 # Projects
 
-Make okra great (OKRA1)
+- Make okra great (OKRA1)
 
 # Last Week
 


### PR DESCRIPTION
Currently the `# Projects` section prints each project (i.e. KR) on a newline which looks fine when viewed in the raw file but is rendered as a single paragraph by markdown. This PR changes them to a list.