### PR TITLE
Add lint subcommand

### DIFF
--- a/bin/generate.ml
+++ b/bin/generate.ml
@@ -89,15 +89,16 @@ let term =
 
 let cmd =
   let info =
-    Term.info "generate" ~doc:"Generate an initial weekly report based on Github activity"
+    Term.info "generate"
+      ~doc:"Generate an initial weekly report based on Github activity"
       ~man:
         [
           `S Manpage.s_description;
           `P
-            "Produces a markdown document using your activity \
-             on Github. See the options below for changing things like which \
-             week to query for and where to find your token. To generate a \
-             token see the README at https://github.com/talex5/get-activity.";
+            "Produces a markdown document using your activity on Github. See \
+             the options below for changing things like which week to query \
+             for and where to find your token. To generate a token see the \
+             README at https://github.com/talex5/get-activity.";
         ]
   in
   (term, info)

--- a/bin/generate.ml
+++ b/bin/generate.ml
@@ -89,12 +89,12 @@ let term =
 
 let cmd =
   let info =
-    Term.info "generate" ~doc:"generate a get-activity report"
+    Term.info "generate" ~doc:"Generate an initial weekly report based on Github activity"
       ~man:
         [
           `S Manpage.s_description;
           `P
-            "Produces a markdown document using get-activity of your activity \
+            "Produces a markdown document using your activity \
              on Github. See the options below for changing things like which \
              week to query for and where to find your token. To generate a \
              token see the README at https://github.com/talex5/get-activity.";

--- a/bin/lint.ml
+++ b/bin/lint.ml
@@ -22,22 +22,21 @@ type t = {
 
 open Cmdliner
 
-let files_term =
-  Arg.(value & (pos_all non_dir_file []) & info [] ~docv:"FILE")
+let files_term = Arg.(value & pos_all non_dir_file [] & info [] ~docv:"FILE")
 
 let include_sections_term =
   let info =
     Arg.info [ "include-sections" ]
       ~doc:
-        "If non-empty, only lint entries under these sections - everything else is ignored."
+        "If non-empty, only lint entries under these sections - everything \
+         else is ignored."
   in
   Arg.value (Arg.opt (Arg.list Arg.string) [] info)
 
 let ignore_sections_term =
   let info =
     Arg.info [ "ignore-sections" ]
-      ~doc:
-        "If non-empty, don't lint entries under the specified sections."
+      ~doc:"If non-empty, don't lint entries under the specified sections."
   in
   Arg.value (Arg.opt (Arg.list Arg.string) [] info)
 
@@ -45,7 +44,8 @@ let engineer_term =
   let info =
     Arg.info [ "engineer"; "e" ]
       ~doc:
-        "Lint an engineer report. This is an alias for --include-sections=\"last week\", --ignore-sections=\"\""
+        "Lint an engineer report. This is an alias for \
+         --include-sections=\"last week\", --ignore-sections=\"\""
   in
   Arg.value (Arg.flag info)
 
@@ -53,59 +53,49 @@ let team_term =
   let info =
     Arg.info [ "team"; "t" ]
       ~doc:
-        "Lint a team report. This is an alias for --include-sections=\"\", --ignore-sections=\"OKR updates\""
+        "Lint a team report. This is an alias for --include-sections=\"\", \
+         --ignore-sections=\"OKR updates\""
   in
   Arg.value (Arg.flag info)
 
 let run conf =
   let success = ref true in
-  if List.length conf.files > 0 then (
-    List.iter
-      (fun f ->  
-        let ic = open_in f in
-        try
-          let res = Okra.Lint.lint ~include_sections:conf.include_sections ~ignore_sections:conf.ignore_sections ic in
-          if (not res) then success := res else ();
-          close_in ic;
-        with e->
-          close_in_noerr ic;
-          Printf.fprintf stderr "Caught error while linting:\n\n";
-          raise e
-      ) conf.files)
-  else (
+  (if List.length conf.files > 0 then
+   List.iter
+     (fun f ->
+       let ic = open_in f in
+       try
+         let res =
+           Okra.Lint.lint ~include_sections:conf.include_sections
+             ~ignore_sections:conf.ignore_sections ic
+         in
+         if not res then success := res else ();
+         close_in ic
+       with e ->
+         close_in_noerr ic;
+         Printf.fprintf stderr "Caught error while linting:\n\n";
+         raise e)
+     conf.files
+  else
     try
-      let res = Okra.Lint.lint ~include_sections:conf.include_sections ~ignore_sections:conf.ignore_sections stdin in
-      if (not res) then success := res else ()
-    with e->
+      let res =
+        Okra.Lint.lint ~include_sections:conf.include_sections
+          ~ignore_sections:conf.ignore_sections stdin
+      in
+      if not res then success := res else ()
+    with e ->
       Printf.fprintf stderr "Caught error while linting:\n\n";
-      raise e
-  );
-  if not !success then (
-    exit 1)
-  else ()
+      raise e);
+  if not !success then exit 1 else ()
 
 let term =
   let lint include_sections ignore_sections engineer team files =
     let conf =
-      if engineer then (
-        {
-          include_sections = ["Last week"];
-          ignore_sections = [];
-          files;
-        })
-      else
-      if team then (
-        {
-          include_sections;
-          ignore_sections = ["OKR updates"];
-          files;
-        })
-      else (
-          {
-            include_sections;
-            ignore_sections;
-            files;
-          })
+      if engineer then
+        { include_sections = [ "Last week" ]; ignore_sections = []; files }
+      else if team then
+        { include_sections; ignore_sections = [ "OKR updates" ]; files }
+      else { include_sections; ignore_sections; files }
     in
     run conf
   in
@@ -119,14 +109,15 @@ let term =
 
 let cmd =
   let info =
-    Term.info "lint" ~doc:"Check for formatting errors and missing information in the report"
+    Term.info "lint"
+      ~doc:"Check for formatting errors and missing information in the report"
       ~man:
         [
           `S Manpage.s_description;
           `P
-            "Check for general formatting errors, then attempt to parse the report and look for inconsistencies.";
-          `P
-            "Reads from stdin if no files are specified.";
+            "Check for general formatting errors, then attempt to parse the \
+             report and look for inconsistencies.";
+          `P "Reads from stdin if no files are specified.";
         ]
   in
   (term, info)

--- a/bin/lint.ml
+++ b/bin/lint.ml
@@ -1,0 +1,83 @@
+(*
+ * Copyright (c) 2021 Magnus Skjegstad <magnus@skjegstad.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+type t = {
+  include_sections : string list;
+  files : string list;
+}
+
+open Cmdliner
+
+let files_term =
+  Arg.(value & (pos_all non_dir_file []) & info [] ~docv:"FILE")
+
+let include_sections_term =
+  let info =
+    Arg.info [ "include-sections" ]
+      ~doc:
+        "If non-empty, only lint entries under these sections - everything else is ignored."
+  in
+  Arg.value (Arg.opt (Arg.list Arg.string) [] info)
+
+let run conf =
+  if List.length conf.files > 0 then (
+    List.iter
+      (fun f ->  
+        let ic = open_in f in
+        try
+          let _ = Okra.Lint.lint ~include_sections:conf.include_sections ic in
+          close_in ic;
+        with e->
+          close_in_noerr ic;
+          Printf.fprintf stderr "Caught error while linting:\n\n";
+          raise e
+      ) conf.files)
+  else (
+    try
+      let _ = Okra.Lint.lint stdin in ()
+    with e->
+      Printf.fprintf stderr "Caught error while linting:\n\n";
+      raise e
+  )
+
+let term =
+  let lint include_sections files =
+    let conf =
+      {
+        include_sections;
+        files;
+      }
+    in
+    run conf
+  in
+  Term.(
+    const lint
+    $ include_sections_term
+    $ files_term)
+
+let cmd =
+  let info =
+    Term.info "lint" ~doc:"Check for formatting errors and missing information in the report"
+      ~man:
+        [
+          `S Manpage.s_description;
+          `P
+            "Check for general formatting errors, then attempt to parse the report and look for inconsistencies.";
+          `P
+            "Reads from stdin if no files are specified.";
+        ]
+  in
+  (term, info)

--- a/bin/lint.ml
+++ b/bin/lint.ml
@@ -38,7 +38,7 @@ let ignore_sections_term =
     Arg.info [ "ignore-sections" ]
       ~doc:"If non-empty, don't lint entries under the specified sections."
   in
-  Arg.value (Arg.opt (Arg.list Arg.string) [] info)
+  Arg.value (Arg.opt (Arg.list Arg.string) ["OKR updates"] info)
 
 let engineer_term =
   let info =

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -33,4 +33,4 @@ let root_cmd =
   in
   (root_term, info)
 
-let () = Term.(exit @@ eval_choice root_cmd [ Cat.cmd; Generate.cmd ])
+let () = Term.(exit @@ eval_choice root_cmd [ Cat.cmd; Lint.cmd; Generate.cmd ])

--- a/src/aggregate.ml
+++ b/src/aggregate.ml
@@ -28,6 +28,10 @@ exception No_work_found of string (* No work items found under KR *)
 
 exception Multiple_time_entries of string (* More than one time entry found *)
 
+exception No_KR_ID_found of string (* Empty or no KR ID *)
+
+exception No_title_found of string (* No title found *)
+
 (* Type for sanitized post-ast version *)
 type t = {
   counter : int;
@@ -330,8 +334,8 @@ type state = {
 
 let init ?(ignore_sections = []) ?(include_sections = []) () =
   {
-    current_o = "None";
-    current_proj = "Unknown";
+    current_o = "";
+    current_proj = "";
     current_counter = 0;
     ignore_sections;
     include_sections;
@@ -516,6 +520,23 @@ let of_weekly okr_list =
   if List.length work == 0 then
     raise
       (No_work_found (Fmt.str "KR with ID %s is without work items" !okr_kr_id))
+  else ();
+
+  if String.length (String.trim !okr_kr_id) == 0 then
+    raise
+      (No_KR_ID_found
+         (Fmt.str "No KR ID found for \"%s\" (under objective %s)" !okr_kr_title
+            !okr_obj))
+  else ();
+
+  if
+    String.length (String.trim !okr_proj) == 0
+    || String.length (String.trim !okr_obj) == 0
+  then
+    raise
+      (No_title_found
+         (Fmt.str "No title for project or objective found for \"%s\""
+            !okr_kr_title))
   else ();
 
   (* Construct final entry *)

--- a/src/aggregate.mli
+++ b/src/aggregate.mli
@@ -43,13 +43,13 @@ module Weekly : sig
   val filter : t -> string -> t
 end
 
-(** Process markdown data from omd. Optionally [ignore_sections] can be used to
-ignore specific sections, or [include_sections] can be used to only process 
-specific sections. *)
 val process :
   ?ignore_sections:string list ->
   ?include_sections:string list ->
   (string * string) list Omd.block list ->
   Weekly.table
+(** Process markdown data from omd. Optionally [ignore_sections] can be used to
+    ignore specific sections, or [include_sections] can be used to only process
+    specific sections. *)
 
 val of_weekly : Weekly.t -> t

--- a/src/aggregate.mli
+++ b/src/aggregate.mli
@@ -19,6 +19,8 @@ exception No_time_found of string
 exception Multiple_time_entries of string
 exception Invalid_time of string
 exception No_work_found of string
+exception No_KR_ID_found of string
+exception No_title_found of string
 
 type t = {
   counter : int;

--- a/src/aggregate.mli
+++ b/src/aggregate.mli
@@ -41,8 +41,12 @@ module Weekly : sig
   val filter : t -> string -> t
 end
 
+(** Process markdown data from omd. Optionally [ignore_sections] can be used to
+ignore specific sections, or [include_sections] can be used to only process 
+specific sections. *)
 val process :
   ?ignore_sections:string list ->
+  ?include_sections:string list ->
   (string * string) list Omd.block list ->
   Weekly.table
 

--- a/src/aggregate.mli
+++ b/src/aggregate.mli
@@ -17,6 +17,8 @@
 
 exception No_time_found of string
 exception Multiple_time_entries of string
+exception Invalid_time of string
+exception No_work_found of string
 
 type t = {
   counter : int;

--- a/src/lint.ml
+++ b/src/lint.ml
@@ -15,48 +15,80 @@
  *)
 
 let fail_fmt_patterns =
-  [ 
-    (Str.regexp ".*\t"), "Tab found. Use spaces for indentation (2 preferred).";
-    (Str.regexp ".*-  "), "Double space before text after bullet point ('-  text'), this can confuse the parser. Use '- text'";
-    (Str.regexp "^ -"), "Single space used for indentation (' - text'). Remove or replace by 2 or more spaces.";
-    (Str.regexp "^[ ]*\\*"), "* used as bullet point, this can confuse the parser. Only use - as bullet marker.";
-    (Str.regexp "^[ ]*\\+"), "+ used as bullet point, this can confuse the parser. Only use - as bullet marker.";
-    (Str.regexp "^[ ]+#"), "Space found before title marker #. Start titles in first column.";
+  [
+    (Str.regexp ".*\t", "Tab found. Use spaces for indentation (2 preferred).");
+    ( Str.regexp ".*-  ",
+      "Double space before text after bullet point ('-  text'), this can \
+       confuse the parser. Use '- text'" );
+    ( Str.regexp "^ -",
+      "Single space used for indentation (' - text'). Remove or replace by 2 \
+       or more spaces." );
+    ( Str.regexp "^[ ]*\\*",
+      "* used as bullet point, this can confuse the parser. Only use - as \
+       bullet marker." );
+    ( Str.regexp "^[ ]*\\+",
+      "+ used as bullet point, this can confuse the parser. Only use - as \
+       bullet marker." );
+    ( Str.regexp "^[ ]+#",
+      "Space found before title marker #. Start titles in first column." );
   ]
 
-let lint ?(include_sections=[]) ?(ignore_sections=[]) ic =
-  let failures = ref 0 in 
+let lint ?(include_sections = []) ?(ignore_sections = []) ic =
+  let failures = ref 0 in
   let rec check_and_read buf ic pos =
-    (try
+    try
       let line = input_line ic in
       List.iter
         (fun (regexp, msg) ->
           if Str.string_match regexp line 0 then (
             Printf.printf "Line %n: %s\n" pos msg;
             failures := !failures + 1)
-          else ()
-        ) fail_fmt_patterns;
+          else ())
+        fail_fmt_patterns;
       Buffer.add_string buf line;
       Buffer.add_string buf "\n";
       check_and_read buf ic (pos + 1)
     with
     | End_of_file -> Buffer.contents buf
-    | e -> raise e)
-  in 
+    | e -> raise e
+  in
   let s = check_and_read (Buffer.create 1024) ic 1 in
-  if (!failures > 0) then
-    false
-  else (
+  if !failures > 0 then false
+  else
     (* parse and without output to sanity check *)
-    (try
+    try
       let md = Omd.of_string s in
-      let okrs = Aggregate.process ~include_sections:include_sections ~ignore_sections:ignore_sections md in
-      let _ = List.map Aggregate.of_weekly (List.of_seq (Hashtbl.to_seq_values okrs)) in
+      let okrs = Aggregate.process ~include_sections ~ignore_sections md in
+      let _ =
+        List.map Aggregate.of_weekly (List.of_seq (Hashtbl.to_seq_values okrs))
+      in
       true
     with
-    | Aggregate.No_time_found s -> Printf.printf "No time entry found. Each KR must be followed by '- @... (x days)\nError: %s\n" s; false
-    | Aggregate.Invalid_time s -> Printf.printf "Invalid time entry found. Format is '- @eng1 (x days), @eng2 (x days)'\nError: %s\n" s; false
-    | Aggregate.Multiple_time_entries s -> Printf.printf "KR with multiple time entries found. Only one time entry should follow immediately after the KR.\nError: %s\n" s; false
-    | Aggregate.No_work_found s -> Printf.printf "No work items found. This may indicate an unreported parsing error. Remove the KR if it is without work.\nError: %s\n" s; false)
-  )
-  (* read into buffer while checking formatting, then send final string to omd for parsing and sanity checks *)
+    | Aggregate.No_time_found s ->
+        Printf.printf
+          "No time entry found. Each KR must be followed by '- @... (x days)\n\
+           Error: %s\n"
+          s;
+        false
+    | Aggregate.Invalid_time s ->
+        Printf.printf
+          "Invalid time entry found. Format is '- @eng1 (x days), @eng2 (x \
+           days)'\n\
+           Error: %s\n"
+          s;
+        false
+    | Aggregate.Multiple_time_entries s ->
+        Printf.printf
+          "KR with multiple time entries found. Only one time entry should \
+           follow immediately after the KR.\n\
+           Error: %s\n"
+          s;
+        false
+    | Aggregate.No_work_found s ->
+        Printf.printf
+          "No work items found. This may indicate an unreported parsing error. \
+           Remove the KR if it is without work.\n\
+           Error: %s\n"
+          s;
+        false
+(* read into buffer while checking formatting, then send final string to omd for parsing and sanity checks *)

--- a/src/lint.ml
+++ b/src/lint.ml
@@ -21,6 +21,8 @@ type lint_result =
   | Invalid_time of string
   | Multiple_time_entries of string
   | No_work_found of string
+  | No_KR_ID_found of string
+  | No_title_found of string
 
 let fail_fmt_patterns =
   [
@@ -79,6 +81,20 @@ let string_of_result res =
            "No work items found. This may indicate an unreported parsing \
             error. Remove the KR if it is without work.\n\
             Error: %s\n"
+           s)
+  | No_title_found s ->
+      Buffer.add_string buf
+        (Fmt.str
+           "The input should contain at least one title (starting with #)\n\
+            Error: %s\n"
+           s)
+  | No_KR_ID_found s ->
+      Buffer.add_string buf
+        (Fmt.str
+           "No KR ID found. KRs should be in the format \"This is a KR \
+            (PLAT123)\", where PLAT123 is the KR ID. For KRs that don't have \
+            an ID yet, use \"New KR\".\n\
+            Error: %s\n"
            s));
   Buffer.contents buf
 
@@ -117,3 +133,5 @@ let lint ?(include_sections = []) ?(ignore_sections = []) ic =
     | Aggregate.Invalid_time s -> Invalid_time s
     | Aggregate.Multiple_time_entries s -> Multiple_time_entries s
     | Aggregate.No_work_found s -> No_work_found s
+    | Aggregate.No_KR_ID_found s -> No_KR_ID_found s
+    | Aggregate.No_title_found s -> No_title_found s

--- a/src/lint.ml
+++ b/src/lint.ml
@@ -24,7 +24,7 @@ let fail_fmt_patterns =
     (Str.regexp "^[ ]+#"), "Space found before title marker #. Start titles in first column.";
   ]
 
-let lint ?(include_sections=[]) ic =
+let lint ?(include_sections=[]) ?(ignore_sections=[]) ic =
   let failures = ref 0 in 
   let rec check_and_read buf ic pos =
     (try
@@ -50,7 +50,7 @@ let lint ?(include_sections=[]) ic =
     (* parse and without output to sanity check *)
     (try
       let md = Omd.of_string s in
-      let okrs = Aggregate.process ~include_sections:include_sections md in
+      let okrs = Aggregate.process ~include_sections:include_sections ~ignore_sections:ignore_sections md in
       let _ = List.map Aggregate.of_weekly (List.of_seq (Hashtbl.to_seq_values okrs)) in
       true
     with

--- a/src/lint.ml
+++ b/src/lint.ml
@@ -1,0 +1,62 @@
+(*
+ * Copyright (c) 2021 Magnus Skjegstad <magnus@skjegstad.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+let fail_fmt_patterns =
+  [ 
+    (Str.regexp ".*\t"), "Tab found. Use spaces for indentation (2 preferred).";
+    (Str.regexp ".*-  "), "Double space before text after bullet point ('-  text'), this can confuse the parser. Use '- text'";
+    (Str.regexp "^ -"), "Single space used for indentation (' - text'). Remove or replace by 2 or more spaces.";
+    (Str.regexp "^[ ]*\\*"), "* used as bullet point, this can confuse the parser. Only use - as bullet marker.";
+    (Str.regexp "^[ ]*\\+"), "+ used as bullet point, this can confuse the parser. Only use - as bullet marker.";
+    (Str.regexp "^[ ]+#"), "Space found before title marker #. Start titles in first column.";
+  ]
+
+let lint ?(include_sections=[]) ic =
+  let failures = ref 0 in 
+  let rec check_and_read buf ic pos =
+    (try
+      let line = input_line ic in
+      List.iter
+        (fun (regexp, msg) ->
+          if Str.string_match regexp line 0 then (
+            Printf.printf "Line %n: %s\n" pos msg;
+            failures := !failures + 1)
+          else ()
+        ) fail_fmt_patterns;
+      Buffer.add_string buf line;
+      Buffer.add_string buf "\n";
+      check_and_read buf ic (pos + 1)
+    with
+    | End_of_file -> Buffer.contents buf
+    | e -> raise e)
+  in 
+  let s = check_and_read (Buffer.create 1024) ic 1 in
+  if (!failures > 0) then
+    false
+  else (
+    (* parse and without output to sanity check *)
+    (try
+      let md = Omd.of_string s in
+      let okrs = Aggregate.process ~include_sections:include_sections md in
+      let _ = List.map Aggregate.of_weekly (List.of_seq (Hashtbl.to_seq_values okrs)) in
+      true
+    with
+    | Aggregate.No_time_found s -> Printf.printf "No time entry found. Each KR must be followed by '- @... (x days)\nError: %s\n" s; false
+    | Aggregate.Invalid_time s -> Printf.printf "Invalid time entry found. Format is '- @eng1 (x days), @eng2 (x days)'\nError: %s\n" s; false
+    | Aggregate.Multiple_time_entries s -> Printf.printf "KR with multiple time entries found. Only one time entry should follow immediately after the KR.\nError: %s\n" s; false
+    | Aggregate.No_work_found s -> Printf.printf "No work items found. This may indicate an unreported parsing error. Remove the KR if it is without work.\nError: %s\n" s; false)
+  )
+  (* read into buffer while checking formatting, then send final string to omd for parsing and sanity checks *)

--- a/src/lint.mli
+++ b/src/lint.mli
@@ -1,7 +1,5 @@
 (*
- * Copyright (c) 2021 Magnus Skjegstad
- * Copyright (c) 2021 Thomas Gazagnaire <thomas@gazagnaire.org>
- * Copyright (c) 2021 Patrick Ferris <pf341@patricoferris.com>
+ * Copyright (c) 2021 Magnus Skjegstad <magnus@skjegstad.com>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -14,9 +12,6 @@
  * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- *)
+ *) 
 
-module Aggregate = Aggregate
-module Activity = Activity
-module Calendar = Calendar
-module Lint = Lint
+val lint: ?include_sections:(string list) -> in_channel -> bool

--- a/src/lint.mli
+++ b/src/lint.mli
@@ -12,8 +12,10 @@
  * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- *) 
+ *)
 
-val lint: ?include_sections:(string list) ->
-          ?ignore_sections:(string list) ->
-          in_channel -> bool
+val lint :
+  ?include_sections:string list ->
+  ?ignore_sections:string list ->
+  in_channel ->
+  bool

--- a/src/lint.mli
+++ b/src/lint.mli
@@ -14,4 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *) 
 
-val lint: ?include_sections:(string list) -> in_channel -> bool
+val lint: ?include_sections:(string list) ->
+          ?ignore_sections:(string list) ->
+          in_channel -> bool

--- a/src/lint.mli
+++ b/src/lint.mli
@@ -21,6 +21,8 @@ type lint_result =
   | Invalid_time of string
   | Multiple_time_entries of string
   | No_work_found of string
+  | No_KR_ID_found of string
+  | No_title_found of string
 
 val lint :
   ?include_sections:string list ->

--- a/src/lint.mli
+++ b/src/lint.mli
@@ -14,8 +14,18 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+type lint_result =
+  | No_error
+  | Format_error of (int * string) list
+  | No_time_found of string
+  | Invalid_time of string
+  | Multiple_time_entries of string
+  | No_work_found of string
+
 val lint :
   ?include_sections:string list ->
   ?ignore_sections:string list ->
   in_channel ->
-  bool
+  lint_result
+
+val string_of_result : lint_result -> string

--- a/src/okra.mli
+++ b/src/okra.mli
@@ -19,3 +19,4 @@
 module Aggregate = Aggregate
 module Activity = Activity
 module Calendar = Calendar
+module Lint = Lint

--- a/test/dune
+++ b/test/dune
@@ -1,3 +1,5 @@
 (test
  (name test)
+ (deps
+  (source_tree lint))
  (libraries alcotest okra))

--- a/test/lint/eng1.acc
+++ b/test/lint/eng1.acc
@@ -7,7 +7,7 @@ This is not formatted.
 
 # Last week
 
-- This is a KR (KRID)
+- This is a KR (KR123)
   - @eng1 (1 day)
   - My work
 

--- a/test/lint/eng1.acc
+++ b/test/lint/eng1.acc
@@ -1,0 +1,16 @@
+# Projects
+
+- Project1 (KR1)
+- Project2 (KR2)
+
+This is not formatted.
+
+# Last week
+
+- This is a KR (KRID)
+  - @eng1 (1 day)
+  - My work
+
+# Activity
+
+More unformatted text.

--- a/test/lint/eng1.rej
+++ b/test/lint/eng1.rej
@@ -1,0 +1,16 @@
+# Projects
+
+- Project1 (KR1)
+- Project2 (KR2)
+
+This is not formatted.
+
+# Last week
+
+- This is a KR (KRID)
+  - (1 day)
+  - My work
+
+# Activity
+
+More unformatted text.

--- a/test/lint/format1.rej
+++ b/test/lint/format1.rej
@@ -1,0 +1,5 @@
+# Title
+
+- This is a KR (KRID)
+  - @eng1 (1 day)
+  + My work

--- a/test/lint/format2.rej
+++ b/test/lint/format2.rej
@@ -1,0 +1,5 @@
+ # Title
+
+- This is a KR (KRID)
+  - @eng1 (1 day)
+  - My work

--- a/test/lint/format3.rej
+++ b/test/lint/format3.rej
@@ -1,0 +1,5 @@
+# Title
+
+ - This is a KR (KRID)
+  - @eng1 (1 day)
+  - My work

--- a/test/lint/invalid-time1.rej
+++ b/test/lint/invalid-time1.rej
@@ -1,0 +1,5 @@
+# Title
+
+- This is a KR (KRID)
+  - @eng1 (1 day), eng2 (2 days)
+  - My work

--- a/test/lint/invalid-time2.rej
+++ b/test/lint/invalid-time2.rej
@@ -1,0 +1,5 @@
+# Title
+
+- This is a KR (KRID)
+  - @eng1 (1 day); @eng2 (2 days)
+  - My work

--- a/test/lint/invalid-time3.rej
+++ b/test/lint/invalid-time3.rej
@@ -1,0 +1,5 @@
+# Title
+
+- This is a KR (KRID)
+  - @eng1 (1 day) @eng2 (2 days)
+  - My work

--- a/test/lint/multitime1.rej
+++ b/test/lint/multitime1.rej
@@ -1,0 +1,7 @@
+# Title
+
+- This is a KR (KRID)
+  - @eng1 (1 day)
+  - My work
+  - @eng2 (2 days)
+  - More work

--- a/test/lint/no-kr1.rej
+++ b/test/lint/no-kr1.rej
@@ -1,0 +1,5 @@
+# Title
+
+- This is a KR
+  - @eng1 (1 day)
+  - My work

--- a/test/lint/no-time1.rej
+++ b/test/lint/no-time1.rej
@@ -1,0 +1,5 @@
+# Title
+
+- This is a KR (KRID)
+  - My work
+  - @eng1 (1 day)

--- a/test/lint/no-title1.rej
+++ b/test/lint/no-title1.rej
@@ -1,0 +1,3 @@
+- This is a KR (KRID)
+  - @eng1 (1 day)
+  - My work

--- a/test/lint/no-title1.rej
+++ b/test/lint/no-title1.rej
@@ -1,3 +1,3 @@
-- This is a KR (KRID)
+- This is a KR (KR123)
   - @eng1 (1 day)
   - My work

--- a/test/lint/no-work1.rej
+++ b/test/lint/no-work1.rej
@@ -1,0 +1,4 @@
+# Title
+
+- This is a KR (KRID)
+  - @eng1 (1 day)

--- a/test/lint/team1.acc
+++ b/test/lint/team1.acc
@@ -5,6 +5,6 @@
 
 # This is a title
 
-- This is a KR (KRID)
+- This is a KR (KR123)
   - @eng1 (1 day)
   - My work

--- a/test/lint/team1.acc
+++ b/test/lint/team1.acc
@@ -1,0 +1,10 @@
+# OKR updates
+
+- This is not properly formatted.
+- New KR: Test
+
+# This is a title
+
+- This is a KR (KRID)
+  - @eng1 (1 day)
+  - My work

--- a/test/lint/team1.rej
+++ b/test/lint/team1.rej
@@ -1,0 +1,10 @@
+# OKR updates
+
+- This is not properly formatted.
+- New KR: Test
+
+# This is a title
+
+- This is a KR (KRID)
+  - @eng1 (1 day)
+ - My work

--- a/test/lint/team2.acc
+++ b/test/lint/team2.acc
@@ -1,0 +1,5 @@
+# This is a title
+
+- This is a KR (KRID)
+  - @eng1 (1 day)
+  - My work

--- a/test/lint/team2.acc
+++ b/test/lint/team2.acc
@@ -1,5 +1,5 @@
 # This is a title
 
-- This is a KR (KRID)
+- This is a KR (KR123)
   - @eng1 (1 day)
   - My work

--- a/test/lint/team3.acc
+++ b/test/lint/team3.acc
@@ -2,7 +2,7 @@
 
 ## Another title
 
-- This is a KR (KRID)
+- This is a KR (KR123)
   - @eng1 (1 day), @eng2 (2.5 days), @eng3 (4 days)
   - My work
   - More work

--- a/test/lint/team3.acc
+++ b/test/lint/team3.acc
@@ -1,0 +1,8 @@
+# This is a title
+
+## Another title
+
+- This is a KR (KRID)
+  - @eng1 (1 day), @eng2 (2.5 days), @eng3 (4 days)
+  - My work
+  - More work

--- a/test/test.ml
+++ b/test/test.ml
@@ -14,4 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-let () = Alcotest.run "Okra" [ ("Calendar", Test_calendar.tests) ]
+let () =
+  Alcotest.run "Okra"
+    [ ("Calendar", Test_calendar.tests); ("Lint", Test_lint.tests) ]

--- a/test/test_lint.ml
+++ b/test/test_lint.ml
@@ -95,6 +95,22 @@ let test_invalid_team_report f () =
       Alcotest.fail (Fmt.str "No error when linting invalid team report %s" f)
   | _ -> Alcotest.(check pass) "" 0 0
 
+let test_no_kr_id_found f () =
+  match lint_file f with
+  | Okra.Lint.No_KR_ID_found _ -> Alcotest.(check pass) "" 0 0
+  | x ->
+      Alcotest.fail
+        (Fmt.str "Invalid result in file %s:\n%s" f
+           (Okra.Lint.string_of_result x))
+
+let test_no_title_found f () =
+  match lint_file f with
+  | Okra.Lint.No_title_found _ -> Alcotest.(check pass) "" 0 0
+  | x ->
+      Alcotest.fail
+        (Fmt.str "Invalid result in file %s:\n%s" f
+           (Okra.Lint.string_of_result x))
+
 let tests =
   [
     ("Test_valid_eng_report", `Quick, test_valid_eng_report "./lint/eng1.acc");
@@ -107,6 +123,8 @@ let tests =
     ( "Test_invalid_team_report",
       `Quick,
       test_invalid_team_report "./lint/team1.rej" );
+    ("No_KR_ID_found", `Quick, test_no_kr_id_found "./lint/no-kr1.rej");
+    ("No_title_found", `Quick, test_no_title_found "./lint/no-title1.rej");
     ("No_work_found", `Quick, test_no_work_found "./lint/no-work1.rej");
     ("No_time_found", `Quick, test_no_time_found "./lint/no-time1.rej");
     ( "Multiple_time_entries",

--- a/test/test_lint.ml
+++ b/test/test_lint.ml
@@ -1,0 +1,121 @@
+(*
+ * Copyright (c) 2021 Magnus Skjegstad <magnus@skjegstad.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+let lint_file ?(include_sections = []) ?(ignore_sections = []) f =
+  let ic = open_in f in
+  let res = Okra.Lint.lint ~include_sections ~ignore_sections ic in
+  close_in ic;
+  res
+
+let test_no_work_found f () =
+  match lint_file f with
+  | Okra.Lint.No_work_found _ -> Alcotest.(check pass) "" 0 0
+  | x ->
+      Alcotest.fail
+        (Fmt.str "Invalid result in file %s:\n%s" f
+           (Okra.Lint.string_of_result x))
+
+let test_invalid_time f () =
+  match lint_file f with
+  | Okra.Lint.Invalid_time _ -> Alcotest.(check pass) "" 0 0
+  | x ->
+      Alcotest.fail
+        (Fmt.str "Invalid result in file %s:\n%s" f
+           (Okra.Lint.string_of_result x))
+
+let test_no_time_found f () =
+  match lint_file f with
+  | Okra.Lint.No_time_found _ -> Alcotest.(check pass) "" 0 0
+  | x ->
+      Alcotest.fail
+        (Fmt.str "Invalid result in file %s:\n%s" f
+           (Okra.Lint.string_of_result x))
+
+let test_multiple_time_entries f () =
+  match lint_file f with
+  | Okra.Lint.Multiple_time_entries _ -> Alcotest.(check pass) "" 0 0
+  | x ->
+      Alcotest.fail
+        (Fmt.str "Invalid result in file %s:\n%s" f
+           (Okra.Lint.string_of_result x))
+
+let test_format_errors f n () =
+  match lint_file f with
+  | Okra.Lint.Format_error l ->
+      Alcotest.(check int)
+        (Fmt.str "Incorrect number of formatting errors in file %s: %s\n" f
+           (Okra.Lint.string_of_result (Okra.Lint.Format_error l)))
+        (List.length l) n
+  | x ->
+      Alcotest.fail
+        (Fmt.str "Invalid result in file %s:\n%s" f
+           (Okra.Lint.string_of_result x))
+
+let test_valid_eng_report f () =
+  match lint_file ~include_sections:[ "Last week" ] f with
+  | Okra.Lint.No_error -> Alcotest.(check pass) "" 0 0
+  | x ->
+      Alcotest.fail
+        (Fmt.str "Invalid result in file %s:\n%s" f
+           (Okra.Lint.string_of_result x))
+
+let test_invalid_eng_report f () =
+  (* Test that errors in include section are detected even if the rest is ignored *)
+  match lint_file ~include_sections:[ "Last week" ] f with
+  | Okra.Lint.No_error ->
+      Alcotest.fail
+        (Fmt.str "No error when linting invalid engineering report %s" f)
+  | _ -> Alcotest.(check pass) "" 0 0
+
+let test_valid_team_report f () =
+  match lint_file ~ignore_sections:[ "OKR Updates" ] f with
+  | Okra.Lint.No_error -> Alcotest.(check pass) "" 0 0
+  | x ->
+      Alcotest.fail
+        (Fmt.str "Invalid result in file %s:\n%s" f
+           (Okra.Lint.string_of_result x))
+
+let test_invalid_team_report f () =
+  (* Test that it doesn't ignore errors outside the ignored section *)
+  match lint_file ~ignore_sections:[ "OKR updates" ] f with
+  | Okra.Lint.No_error ->
+      Alcotest.fail (Fmt.str "No error when linting invalid team report %s" f)
+  | _ -> Alcotest.(check pass) "" 0 0
+
+let tests =
+  [
+    ("Test_valid_eng_report", `Quick, test_valid_eng_report "./lint/eng1.acc");
+    ( "Test_invalid_eng_report",
+      `Quick,
+      test_invalid_eng_report "./lint/eng1.rej" );
+    ("Test_valid_team_report", `Quick, test_valid_team_report "./lint/team1.acc");
+    ("Test_valid_team_report", `Quick, test_valid_team_report "./lint/team2.acc");
+    ("Test_valid_team_report", `Quick, test_valid_team_report "./lint/team3.acc");
+    ( "Test_invalid_team_report",
+      `Quick,
+      test_invalid_team_report "./lint/team1.rej" );
+    ("No_work_found", `Quick, test_no_work_found "./lint/no-work1.rej");
+    ("No_time_found", `Quick, test_no_time_found "./lint/no-time1.rej");
+    ( "Multiple_time_entries",
+      `Quick,
+      test_multiple_time_entries "./lint/multitime1.rej" );
+    ("Format_errors", `Quick, test_format_errors "./lint/format1.rej" 1);
+    ("Format_errors", `Quick, test_format_errors "./lint/format2.rej" 1);
+    ("Format_errors", `Quick, test_format_errors "./lint/format3.rej" 1);
+    ("Invalid_time", `Quick, test_invalid_time "./lint/invalid-time1.rej");
+    ("Invalid_time", `Quick, test_invalid_time "./lint/invalid-time2.rej");
+    ("Invalid_time", `Quick, test_invalid_time "./lint/invalid-time3.rej");
+  ]


### PR DESCRIPTION
Adds a lint subcommand and stricter parsing rules w/tests.

The linter runs in two phases, first it checks the formatting using a set of regular expressions, then it runs the parser to check for other inconsistencies. 

This also makes parsing stricter. It now catches errors in the time format, such as #16 and it will fail on missing KR identifiers or missing titles.

(fixes #16, fixes #10)