### PR TITLE
Fix a time parsing bug and add more tests

### DIFF
--- a/src/aggregate.ml
+++ b/src/aggregate.ml
@@ -552,6 +552,25 @@ let of_weekly okr_list =
     work;
   }
 
+let ht_add_or_sum ht k v =
+  match Hashtbl.find_opt ht k with
+  | None -> Hashtbl.add ht k v
+  | Some x -> Hashtbl.replace ht k (Float.add v x)
+
+let by_engineer ?(include_krs = []) okrs =
+  let v = List.map of_weekly (List.of_seq (Hashtbl.to_seq_values okrs)) in
+  let uppercase_include_krs = List.map String.uppercase_ascii include_krs in
+  let result = Hashtbl.create 7 in
+  List.iter
+    (fun e ->
+      (* only proceed if include_krs is empty or has a match *)
+      if List.length include_krs == 0 || List.mem e.kr_id uppercase_include_krs
+      then
+        Hashtbl.iter (fun k w -> ht_add_or_sum result k w) e.time_per_engineer
+      else ()) (* skip this KR *)
+    v;
+  result
+
 module Unused = struct
   let _tim_re = Str.regexp "@\\([a-zA-Z0-9]+\\) (\\([0-9.]+\\) days?)$"
   (* @[github-handle] ([float] day/days) *)

--- a/src/aggregate.ml
+++ b/src/aggregate.ml
@@ -475,7 +475,8 @@ let of_weekly okr_list =
                 (fun s ->
                   match
                     Str.string_match
-                      (Str.regexp "^\\([a-zA-Z0-9-]+\\)[^0-9]+\\([0-9.]+\\)")
+                      (Str.regexp
+                         "^\\([a-zA-Z0-9-]+\\)[ ]+(\\([0-9.]+\\) day[s]?)")
                       s 0
                   with
                   | false -> ()

--- a/src/aggregate.mli
+++ b/src/aggregate.mli
@@ -55,3 +55,6 @@ val process :
     specific sections. *)
 
 val of_weekly : Weekly.t -> t
+
+val by_engineer :
+  ?include_krs:string list -> Weekly.table -> (string, float) Hashtbl.t

--- a/test/aggregate/valid-time1.acc
+++ b/test/aggregate/valid-time1.acc
@@ -1,0 +1,31 @@
+# Title
+
+- This is a KR (KR123)
+  - @eng1 (.5 day)
+  - My work
+
+- This is a KR (KR124)
+  - @eng1 (.5 days)
+  - My work
+
+- This is a KR (KR124)
+  - @eng1 (0.5 days)
+  - My work
+
+- This is a KR (KR124)
+  - @eng1 (0.5 day)
+  - My work
+
+- Another KR (KR125)
+  - @eng3 (3.5 days), @eng4 (0.5 day)
+  - Work
+
+- This is a KR (KR124)
+  - @eng1 (.5 days), @eng1 (.5 day)
+  - My work
+
+## New title
+
+- Another KR (KR125)
+  - @eng3 (1.5 days), @eng4 (1 day)
+  - Work

--- a/test/dune
+++ b/test/dune
@@ -1,5 +1,6 @@
 (test
  (name test)
  (deps
-  (source_tree lint))
+  (source_tree lint)
+  (source_tree aggregate))
  (libraries alcotest okra))

--- a/test/lint/invalid-time1.rej
+++ b/test/lint/invalid-time1.rej
@@ -1,5 +1,5 @@
 # Title
 
-- This is a KR (KRID)
+- This is a KR (KR123)
   - @eng1 (1 day), eng2 (2 days)
   - My work

--- a/test/lint/invalid-time2.rej
+++ b/test/lint/invalid-time2.rej
@@ -1,5 +1,5 @@
 # Title
 
-- This is a KR (KRID)
+- This is a KR (KR123)
   - @eng1 (1 day); @eng2 (2 days)
   - My work

--- a/test/lint/invalid-time3.rej
+++ b/test/lint/invalid-time3.rej
@@ -1,5 +1,5 @@
 # Title
 
-- This is a KR (KRID)
+- This is a KR (KR123)
   - @eng1 (1 day) @eng2 (2 days)
   - My work

--- a/test/lint/valid-time1.acc
+++ b/test/lint/valid-time1.acc
@@ -1,0 +1,21 @@
+# Title
+
+- This is a KR (KR123)
+  - @eng1 (.5 day)
+  - My work
+
+- This is a KR (KR124)
+  - @eng1 (.5 days)
+  - My work
+
+- This is a KR (KR124)
+  - @eng1 (0.5 days)
+  - My work
+
+- This is a KR (KR124)
+  - @eng1 (0.5 day)
+  - My work
+
+- This is a KR (KR124)
+  - @eng1 (0.1 days), @eng1 (.5 day)
+  - My work

--- a/test/test_aggregate.ml
+++ b/test/test_aggregate.ml
@@ -1,5 +1,5 @@
 (*
- * Copyright (c) 2021 Patrick Ferris <pf341@patricoferris.com>
+ * Copyright (c) 2021 Magnus Skjegstad <magnus@skjegstad.com>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -14,10 +14,23 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-let () =
-  Alcotest.run "Okra"
-    [
-      ("Calendar", Test_calendar.tests);
-      ("Lint", Test_lint.tests);
-      ("Aggregate", Test_aggregate.tests);
-    ]
+let aggregate_by_engineer f =
+  let ic = open_in f in
+  let omd = Omd.of_channel ic in
+  let p = Okra.Aggregate.process omd in
+  let res = Okra.Aggregate.by_engineer p in
+  close_in ic;
+  res
+
+let test_time_parsing f () =
+  let res = aggregate_by_engineer f in
+  Alcotest.(check (float 0.0)) "eng1 time" 3.0 (Hashtbl.find res "eng1");
+  Alcotest.(check (float 0.0)) "eng3 time" 5.0 (Hashtbl.find res "eng3");
+  Alcotest.(check (float 0.0)) "eng4 time" 1.5 (Hashtbl.find res "eng4")
+
+let tests =
+  [
+    ( "Test_time_parsing",
+      `Quick,
+      test_time_parsing "./aggregate/valid-time1.acc" );
+  ]

--- a/test/test_lint.ml
+++ b/test/test_lint.ml
@@ -36,6 +36,14 @@ let test_invalid_time f () =
         (Fmt.str "Invalid result in file %s:\n%s" f
            (Okra.Lint.string_of_result x))
 
+let test_valid_time f () =
+  match lint_file f with
+  | Okra.Lint.No_error -> Alcotest.(check pass) "" 0 0
+  | x ->
+      Alcotest.fail
+        (Fmt.str "Invalid result in file %s:\n%s" f
+           (Okra.Lint.string_of_result x))
+
 let test_no_time_found f () =
   match lint_file f with
   | Okra.Lint.No_time_found _ -> Alcotest.(check pass) "" 0 0
@@ -136,4 +144,5 @@ let tests =
     ("Invalid_time", `Quick, test_invalid_time "./lint/invalid-time1.rej");
     ("Invalid_time", `Quick, test_invalid_time "./lint/invalid-time2.rej");
     ("Invalid_time", `Quick, test_invalid_time "./lint/invalid-time3.rej");
+    ("Valid_time", `Quick, test_valid_time "./lint/valid-time1.acc");
   ]


### PR DESCRIPTION
Previously the linter would accept floats without leading 0, but the parser would then read values like ".5" as ints (5 days instead of 0.5). This fixes the regexp to support floats without leading 0 and adds a test to verify that the time is parsed correctly in these cases. 