### PR TITLE
add repo and org information to links

### DIFF
--- a/test/expect/test_engineer.expected
+++ b/test/expect/test_engineer.expected
@@ -10,5 +10,8 @@
 
 # Activity (move these items to last week)
 
-  - Fix bug in Okra [#42](https://github.com/bactrian/okra/pull/42)
-  - Fix another bug in Okra [#43](https://github.com/bactrian/okra/pull/43)
+  - PR: Fix bug in Okra [bactrian/okra#42](https://github.com/bactrian/okra/pull/42)
+  - PR: Fix another bug in Okra [bactrian/okra#43](https://github.com/bactrian/okra/pull/43)
+  - Issue: There's a bug in Okra [bactrian/okra#26](https://github.com/bactrian/okra/issue/26)
+  - APPROVED Fix another bug in Okra [bactrian/okra#43](https://github.com/bactrian/okra/pull/43#pullrequestreview-123456789)
+  - Created repository [bactrian/okra-web](https://github.com/bactrian/okra-web)

--- a/test/expect/test_engineer.ml
+++ b/test/expect/test_engineer.ml
@@ -37,6 +37,31 @@ let activity =
         body = "Fixes another bug in Okra";
         url = "https://github.com/bactrian/okra/pull/43";
       };
+      {
+        repo = "bactrian/okra";
+        kind = `Issue;
+        date = "";
+        title = "There's a bug in Okra";
+        body = "A bad bug in Okra";
+        url = "https://github.com/bactrian/okra/issue/26";
+      };
+      {
+        repo = "bactrian/okra";
+        kind = `Review "APPROVED";
+        date = "";
+        title = "Fix another bug in Okra";
+        body = "Fixes another bug in Okra";
+        url =
+          "https://github.com/bactrian/okra/pull/43#pullrequestreview-123456789";
+      };
+      {
+        repo = "bactrian/okra-web";
+        kind = `New_repo;
+        date = "";
+        title = "Web";
+        body = "Web";
+        url = "https://github.com/bactrian/okra-web";
+      };
     ]
   in
   let (activity : item list Repo_map.t) =


### PR DESCRIPTION
This PR adds `<repo>/<org>#<id>` information to PRs, Issues and Reviews making it a little more obvious when reading reports formatted on Github or elsewhere where work items belong. The items now also start with `PR:` or `Issue:` for those kinds of items to again help distinguish them when reading rendered versions of the reports. This fixes #23.