### PR TITLE
add template defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ projects:
   - "Improve OKRA (OKRA1)"
 ```
 
+More information is provided at the bottom of the README.
+
 ## Aggregating reports
 
 `okra cat` can be used to aggregate weekly engineer or team reports in a single report. The tool will attempt to group data by project, objective and KR if these match.
@@ -239,3 +241,15 @@ locations:
   - "/path/to/admin/dir1"
   - "/path/to/admin/dir2"
 ```
+
+You can also provide default work items for your projects which are particularly useful for recurring tasks (e.g. meetings). For example: 
+
+```yaml
+projects:
+  - title: "Make okra great (Plat123)"
+    items: 
+      - "Meeting with @MagnusS, @samoht"
+      - "Documenting the tool"
+```
+
+There are [mdx tests](test/bin/README.md) which show the output from such a configuration file.

--- a/bin/conf.mli
+++ b/bin/conf.mli
@@ -20,7 +20,7 @@ type t
 val default : t
 (** A default configuration *)
 
-val projects : t -> string list
+val projects : t -> Okra.Activity.project list
 (** A user's list of activer projects *)
 
 val locations : t -> string list

--- a/bin/generate.ml
+++ b/bin/generate.ml
@@ -100,7 +100,12 @@ let run cal projects token no_activity =
 
 let term =
   let make_with_file cal okra_file token_file no_activity =
-    let token = get_or_error @@ Get_activity.Token.load token_file in
+    let token =
+      (* If [no_activity] is specfied then the token will not be used, don't try
+         to load the file in that case *)
+      if no_activity then ""
+      else get_or_error @@ Get_activity.Token.load token_file
+    in
     let okra_conf =
       match get_or_error @@ Bos.OS.File.exists (Fpath.v okra_file) with
       | false -> Conf.default

--- a/bin/generate.ml
+++ b/bin/generate.ml
@@ -42,6 +42,15 @@ let calendar_term : Calendar.t Term.t =
   in
   Term.(const make $ week_term $ year_term)
 
+let no_activity =
+  Arg.value
+  @@ Arg.flag
+  @@ Arg.info
+       ~doc:
+         "The --no-activity flag will disable any attempt to generate activity \
+          reports from Github"
+       ~docv:"NO-ACTIVITY" [ "no-activity" ]
+
 (* Get activity configuration *)
 let home =
   match Sys.getenv_opt "HOME" with
@@ -69,12 +78,16 @@ let get_or_error = function
 
 module Fetch = Get_activity.Contributions.Fetch (Cohttp_lwt_unix.Client)
 
-let run cal projects token =
+let run cal projects token no_activity =
   let period = Calendar.github_week cal in
   let week = Calendar.week cal in
   let activity =
-    Lwt_main.run (Fetch.exec ~period ~token)
-    |> Get_activity.Contributions.of_json ~from:(fst period)
+    if no_activity then
+      Get_activity.Contributions.
+        { username = "<USERNAME>"; activity = Repo_map.empty }
+    else
+      Lwt_main.run (Fetch.exec ~period ~token)
+      |> Get_activity.Contributions.of_json ~from:(fst period)
   in
   let from, to_ = Calendar.range_of_week cal in
   let format_date f = CalendarLib.Printer.Date.fprint "%0Y/%0m/%0d" f in
@@ -86,16 +99,17 @@ let run cal projects token =
   Fmt.pr "%s\n\n%a" header Activity.pp activity
 
 let term =
-  let make_with_file cal okra_file token_file =
+  let make_with_file cal okra_file token_file no_activity =
     let token = get_or_error @@ Get_activity.Token.load token_file in
     let okra_conf =
       match get_or_error @@ Bos.OS.File.exists (Fpath.v okra_file) with
       | false -> Conf.default
       | true -> get_or_error @@ Conf.load okra_file
     in
-    run cal (Conf.projects okra_conf) token
+    run cal (Conf.projects okra_conf) token no_activity
   in
-  Term.(const make_with_file $ calendar_term $ Conf.cmdliner $ token)
+  Term.(
+    const make_with_file $ calendar_term $ Conf.cmdliner $ token $ no_activity)
 
 let cmd =
   let info =

--- a/dune-project
+++ b/dune-project
@@ -13,6 +13,7 @@
  (description "An executable to be used for report parsing")
  (depends
   (alcotest :with-test)
+  (mdx :with-test)
   okra
   cmdliner
   bos
@@ -30,3 +31,4 @@
   get-activity
   calendar
   (omd (>= 2.0))))
+(using mdx 0.1)

--- a/okra-bin.opam
+++ b/okra-bin.opam
@@ -8,6 +8,7 @@ license: "ISC"
 depends: [
   "dune" {>= "2.8"}
   "alcotest" {with-test}
+  "mdx" {with-test}
   "okra"
   "cmdliner"
   "bos"

--- a/src/activity.ml
+++ b/src/activity.ml
@@ -26,7 +26,7 @@ let pp_last_week username ppf projects =
     Fmt.(pf ppf "%a" (list (fun ppf s -> Fmt.pf ppf "  - %s" s))) t
   in
   let pp_project ppf { title; items } =
-    Fmt.pf ppf "- %s\n  - @%s (<X> days)\n%a" title username pp_items items
+    Fmt.pf ppf "- %s\n  - @%s (<X> days)\n%a@." title username pp_items items
   in
   Fmt.pf ppf "%a" Fmt.(list ~sep:(cut ++ cut) pp_project) projects
 
@@ -73,7 +73,6 @@ let pp ppf { projects; activity = { username; activity } } =
 # Last Week
 
 %a
-
 # Activity (move these items to last week)
 
 %a

--- a/src/activity.ml
+++ b/src/activity.ml
@@ -14,9 +14,19 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+type project = { title : string; items : string list }
+
+let title { title; _ } = title
+
+type t = { projects : project list; activity : Get_activity.Contributions.t }
+
 let pp_last_week username ppf projects =
-  let pp_project ppf t =
-    Fmt.pf ppf "- %s\n  - @%s (<X> days)\n  - Work Item 1" t username
+  let pp_items ppf t =
+    let t = if List.length t = 0 then [ "Work Item 1" ] else t in
+    Fmt.(pf ppf "%a" (list (fun ppf s -> Fmt.pf ppf "  - %s" s))) t
+  in
+  let pp_project ppf { title; items } =
+    Fmt.pf ppf "- %s\n  - @%s (<X> days)\n%a" title username pp_items items
   in
   Fmt.pf ppf "%a" Fmt.(list ~sep:(cut ++ cut) pp_project) projects
 
@@ -52,8 +62,6 @@ let pp_activity ppf activity =
   in
   Fmt.pf ppf "%a" Fmt.(list pp_binding) bindings
 
-type t = { projects : string list; activity : Get_activity.Contributions.t }
-
 let make ~projects activity = { projects; activity }
 
 let pp ppf { projects; activity = { username; activity } } =
@@ -71,4 +79,5 @@ let pp ppf { projects; activity = { username; activity } } =
 %a
 |}
     Fmt.(list (fun ppf s -> Fmt.pf ppf "- %s" s))
-    projects (pp_last_week username) projects pp_activity activity
+    (List.map title projects) (pp_last_week username) projects pp_activity
+    activity

--- a/src/activity.mli
+++ b/src/activity.mli
@@ -17,7 +17,9 @@
 type t
 (** The type for your weekly activity *)
 
-val make : projects:string list -> Get_activity.Contributions.t -> t
+type project = { title : string; items : string list }
+
+val make : projects:project list -> Get_activity.Contributions.t -> t
 (** [make_activity ~projects activites] builds a new weekly activity *)
 
 val pp : t Fmt.t

--- a/test/bin/README.md
+++ b/test/bin/README.md
@@ -119,6 +119,7 @@ $ okra generate --week=37 --year=2021 --no-activity --conf=conf.projects.yaml
   - @<USERNAME> (<X> days)
   - Meetings with people
   - Updating the documentation
+
 - Make a web interface for Okra (OKR2)
   - @<USERNAME> (<X> days)
   - Work Item 1

--- a/test/bin/README.md
+++ b/test/bin/README.md
@@ -1,0 +1,187 @@
+# A User's Guide to Okra
+
+The executable shipped with this package is `okra` which can: 
+
+ - Aggregate weekly reports provided they are in a particular format
+ - Lint reports to check they are in the expected format
+ - Generate a weekly report stub with your Github activity
+
+What follows is some brief examples of how to use `okra` to improve the OKR reporting process.
+
+ - [Engineers](#engineers)
+   * [Generating a report](#generating-a-report)
+   * [Configuring the tool for your projects](#configuring-the-tool-for-your-projects)
+   * [Adding recurring items to your configuration file](#adding-recurring-items-to-your-configuration-file)
+   * [Linting your weekly report](#linting-your-weekly-report)
+
+## Engineers
+
+For the purposes of these [mdx](https://github.com/realworldocaml/mdx) test the tool is being run with 
+the `--no-activity` flag which disables reading the Github token and sending API requests to Github. In
+a real world scenario you are unlikely to want to pass this flag.
+
+### Generating a report
+
+<!-- $MDX dir=files -->
+```sh
+$ okra generate --week=37 --year=2021 --no-activity --conf=conf.simple.yaml
+<USERNAME> week 37: 2021/09/13 -- 2021/09/19
+
+# Projects
+
+- Make Okra, the OKR management tool (OKR1)
+- Make a web interface for Okra (OKR2)
+
+# Last Week
+
+- Make Okra, the OKR management tool (OKR1)
+  - @<USERNAME> (<X> days)
+  - Work Item 1
+
+- Make a web interface for Okra (OKR2)
+  - @<USERNAME> (<X> days)
+  - Work Item 1
+
+# Activity (move these items to last week)
+
+
+```
+
+This generates the skeleton stubs for your report. Without `--no-activity` this will be able to fill in your username.
+Specifying `--week` and `--year` generates the report for the right week and year. In this file they are always specified
+to make the output deterministic but both will default to the current week and year.
+
+### Configuring the tool for your projects
+
+You might have specific projects (KRs) you work on for a period of time (potentially long periods of time) and you can
+supply these to Okra via the configuration file to make the stub generation even better. 
+
+The configuration file for `okra` allows you to setup some default values and locations that should improve the user-experience of using the CLI tool. Everything in the configuration file is optional (including the file itself). The format uses [yaml](https://learnxinyminutes.com/docs/yaml/) and is structured as: 
+
+ - `projects` can either be a `string list` of titles (e.g. `"Implement Okra (OKRA1)"`) or you can also write them as an object with two key-values, one called `title` with `string` as before and an optional one called `items` which is a `string list` of default items to fill in below each KR.
+ - `locations` contains a `string list` of locations (currently this is unused).
+
+<!-- $MDX dir=files -->
+```sh
+$ cat conf.simple.yaml
+projects:
+  - "Make Okra, the OKR management tool (OKR1)"
+  - "Make a web interface for Okra (OKR2)"
+$ okra generate --week=37 --year=2021  --no-activity --conf=conf.simple.yaml
+<USERNAME> week 37: 2021/09/13 -- 2021/09/19
+
+# Projects
+
+- Make Okra, the OKR management tool (OKR1)
+- Make a web interface for Okra (OKR2)
+
+# Last Week
+
+- Make Okra, the OKR management tool (OKR1)
+  - @<USERNAME> (<X> days)
+  - Work Item 1
+
+- Make a web interface for Okra (OKR2)
+  - @<USERNAME> (<X> days)
+  - Work Item 1
+
+# Activity (move these items to last week)
+
+
+```
+
+By default the path to Okra's configuration file is `~/.okra/conf.yaml`.
+
+### Adding recurring items to your configuration file
+
+By default the generator adds `Work Item 1` to each project to remind you there should be at least one work item. For some projects you might have some recurring work items every week (e.g. lots of meetings), you can add these to your configuration file.
+
+<!-- $MDX dir=files -->
+```sh
+$ cat conf.projects.yaml
+projects:
+  - title: "Make Okra, the OKR management tool (OKR1)"
+    items:
+      - "Meetings with people"
+      - "Updating the documentation"
+  - title: "Make a web interface for Okra (OKR2)"
+$ okra generate --week=37 --year=2021 --no-activity --conf=conf.projects.yaml
+<USERNAME> week 37: 2021/09/13 -- 2021/09/19
+
+# Projects
+
+- Make Okra, the OKR management tool (OKR1)
+- Make a web interface for Okra (OKR2)
+
+# Last Week
+
+- Make Okra, the OKR management tool (OKR1)
+  - @<USERNAME> (<X> days)
+  - Meetings with people
+  - Updating the documentation
+- Make a web interface for Okra (OKR2)
+  - @<USERNAME> (<X> days)
+  - Work Item 1
+
+# Activity (move these items to last week)
+
+
+```
+
+### Linting your weekly report
+
+Having a format helps automate a lot of other tasks and the stub generation gets the report 
+very close to being in the correct format. You can `lint` the format locally using `okra`.
+
+Here's an example of a malformed report where Bactrian has forgotten to fill in the time spent 
+on their first KR.
+
+<!-- $MDX dir=files -->
+```sh
+$ cat bactrian.bad.md
+# Projects
+
+- Make Okra, the OKR management tool (OKR1)
+- Make a web interface for Okra (OKR2)
+
+# Last Week
+
+- Make Okra, the OKR management tool (OKR1)
+  - @bactrian (<X> days)
+  - added mdx tests
+
+- Make a web interface for Okra (OKR2)
+  - @bactrian (3 days)
+  - wrote some html
+$ okra lint --engineer bactrian.bad.md
+Error(s) in file bactrian.bad.md:
+
+No time entry found. Each KR must be followed by '-
+.. (x days)
+Error: WARNING: Time not found. Ignored P: Last Week, O: Last Week, Cnt: 1, KR: Make Okra, the OKR management tool (OKR1), KR title: Make Okra, the OKR management tool, KR id: OKR1
+
+[1]
+```
+And here's an example of a well-formatted report:
+<!-- $MDX dir=files -->
+```sh
+$ cat bactrian.good.md
+# Projects
+
+- Make Okra, the OKR management tool (OKR1)
+- Make a web interface for Okra (OKR2)
+
+# Last Week
+
+- Make Okra, the OKR management tool (OKR1)
+  - @bactrian (2 days)
+  - added mdx tests
+
+- Make a web interface for Okra (OKR2)
+  - @bactrian (3 days)
+  - wrote some html
+$ okra lint --engineer bactrian.good.md
+```
+
+## Team Leads
+### Coming soon...

--- a/test/bin/dune
+++ b/test/bin/dune
@@ -1,0 +1,3 @@
+(mdx
+ (packages okra-bin)
+ (files README.md))

--- a/test/bin/files/bactrian.bad.md
+++ b/test/bin/files/bactrian.bad.md
@@ -1,0 +1,14 @@
+# Projects
+
+- Make Okra, the OKR management tool (OKR1)
+- Make a web interface for Okra (OKR2)
+
+# Last Week
+
+- Make Okra, the OKR management tool (OKR1)
+  - @bactrian (<X> days)
+  - added mdx tests
+
+- Make a web interface for Okra (OKR2)
+  - @bactrian (3 days)
+  - wrote some html

--- a/test/bin/files/bactrian.good.md
+++ b/test/bin/files/bactrian.good.md
@@ -1,0 +1,14 @@
+# Projects
+
+- Make Okra, the OKR management tool (OKR1)
+- Make a web interface for Okra (OKR2)
+
+# Last Week
+
+- Make Okra, the OKR management tool (OKR1)
+  - @bactrian (2 days)
+  - added mdx tests
+
+- Make a web interface for Okra (OKR2)
+  - @bactrian (3 days)
+  - wrote some html

--- a/test/bin/files/conf.projects.yaml
+++ b/test/bin/files/conf.projects.yaml
@@ -1,0 +1,6 @@
+projects:
+  - title: "Make Okra, the OKR management tool (OKR1)"
+    items: 
+      - "Meetings with people"
+      - "Updating the documentation" 
+  - title: "Make a web interface for Okra (OKR2)"

--- a/test/bin/files/conf.simple.yaml
+++ b/test/bin/files/conf.simple.yaml
@@ -1,0 +1,3 @@
+projects:
+  - "Make Okra, the OKR management tool (OKR1)"
+  - "Make a web interface for Okra (OKR2)"

--- a/test/expect/test_engineer.ml
+++ b/test/expect/test_engineer.ml
@@ -18,7 +18,9 @@ open Okra
 
 let activity =
   let open Get_activity.Contributions in
-  let projects = [ "Make okra great (OKRA1)" ] in
+  let projects =
+    [ Activity.{ title = "Make okra great (OKRA1)"; items = [] } ]
+  in
   let items : item list =
     [
       {


### PR DESCRIPTION
This PR allows a user to add an `items` section to their projects in order to specify a default list of work items to be added to a project (probably meetings or recurring events). It has been added in a backward compatible way with the previous format of the configuration file. 

This PR also replaces #19 as to be more confident with that backwards compatible claim I needed binary testing.

cc: @samoht (in relation to offline discussions around this) and @dra27, this doesn't provide a new section template as in #34 but does overlap a little bit I think :)) 