### PR TITLE
add engineer heading with week and timeframe

### DIFF
--- a/bin/generate.ml
+++ b/bin/generate.ml
@@ -70,13 +70,15 @@ let get_or_error = function
 module Fetch = Get_activity.Contributions.Fetch (Cohttp_lwt_unix.Client)
 
 let run cal projects token =
-  let period = Calendar.github_week cal in
+  let ((from, to_) as period) = Calendar.github_week cal in
+  let week = Calendar.week cal in
   let activity =
     Lwt_main.run (Fetch.exec ~period ~token)
     |> Get_activity.Contributions.of_json ~from:(fst period)
   in
+  let header = Fmt.str "%s week %i: %s -- %s" activity.username week from to_ in
   let activity = Activity.make ~projects activity in
-  Fmt.pr "%a" Activity.pp activity
+  Fmt.pr "%s\n\n%a" header Activity.pp activity
 
 let term =
   let make_with_file cal okra_file token_file =


### PR DESCRIPTION
This PR adds a simple heading to generated engineer reports with the username, week number and what the week number corresponds to as ISO8601 formatted dates (maybe a little verbose, but was simple to add, let me know if it is too verbose). Fixes #32. 

```sh
dune exec -- okra generate --week=37
patricoferris week 37: 2021-09-13T00:00:00Z -- 2021-09-19T23:59:59Z

# Projects
...
```