### PR TITLE
add markdown spec parser

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -30,5 +30,6 @@
   fmt
   get-activity
   calendar
+  ppx_deriving_yojson
   (omd (>= 2.0))))
 (using mdx 0.1)

--- a/okra.opam
+++ b/okra.opam
@@ -12,6 +12,7 @@ depends: [
   "fmt"
   "get-activity"
   "calendar"
+  "ppx_deriving_yojson"
   "omd" {>= "2.0"}
   "odoc" {with-doc}
 ]

--- a/src/aggregate.mli
+++ b/src/aggregate.mli
@@ -34,6 +34,7 @@ type t = {
 }
 (** TODO: make it abstract *)
 
+val inline : 'a Omd.inline -> string list
 val compare : t -> t -> int
 
 module Weekly : sig

--- a/src/dune
+++ b/src/dune
@@ -1,4 +1,6 @@
 (library
  (name okra)
  (public_name okra)
- (libraries omd fmt str calendar get-activity))
+ (libraries omd fmt str calendar get-activity)
+ (preprocess
+  (pps ppx_deriving_yojson)))

--- a/src/spec.ml
+++ b/src/spec.ml
@@ -1,5 +1,8 @@
 module Kr = struct
-  type schedule = Quarterly of [ `Q1 | `Q2 | `Q3 | `Q4 ] * int | Rolling
+  type schedule =
+    | Quarterly of [ `Q1 | `Q2 | `Q3 | `Q4 ] * int
+    | Rolling
+    | Unknown
   [@@deriving yojson]
 
   type status =
@@ -28,6 +31,7 @@ module Kr = struct
     | Quarterly (q, i) ->
         "(" ^ quarter_to_string q ^ " " ^ string_of_int i ^ ")"
     | Rolling -> "(rolling)"
+    | Unknown -> "()"
 
   let status_of_string s =
     match String.lowercase_ascii s with
@@ -37,6 +41,7 @@ module Kr = struct
     | "blocked" -> Blocked
     | "unfunded" -> Unfunded
     | "scheduled (rolling)" -> Scheduled Rolling
+    | "scheduled ()" -> Scheduled Unknown
     | s -> (
         match String.split_on_char ' ' s with
         | [ "scheduled"; quarter; year ] ->

--- a/src/spec.ml
+++ b/src/spec.ml
@@ -1,0 +1,154 @@
+module Kr = struct
+  type schedule = Quarterly of [ `Q1 | `Q2 | `Q3 | `Q4 ] * int | Rolling
+  [@@deriving yojson]
+
+  type status =
+    | Scheduled of schedule
+    | Unscheduled
+    | No_status
+    | Active
+    | Unfunded
+    | Blocked
+  [@@deriving yojson]
+
+  let quarter_of_string = function
+    | "q1" -> `Q1
+    | "q2" -> `Q2
+    | "q3" -> `Q3
+    | "q4" -> `Q4
+    | _ -> failwith "Failed to parser quarter"
+
+  let quarter_to_string = function
+    | `Q1 -> "Q1"
+    | `Q2 -> "Q2"
+    | `Q3 -> "Q3"
+    | `Q4 -> "Q4"
+
+  let schedule_to_string = function
+    | Quarterly (q, i) ->
+        "(" ^ quarter_to_string q ^ " " ^ string_of_int i ^ ")"
+    | Rolling -> "(rolling)"
+
+  let status_of_string s =
+    match String.lowercase_ascii s with
+    | "unscheduled" -> Unscheduled
+    | "no status" -> No_status
+    | "active" -> Active
+    | "blocked" -> Blocked
+    | "unfunded" -> Unfunded
+    | "scheduled (rolling)" -> Scheduled Rolling
+    | s -> (
+        match String.split_on_char ' ' s with
+        | [ "scheduled"; quarter; year ] ->
+            let quarter =
+              quarter_of_string String.(sub quarter 1 (length quarter - 1))
+            in
+            let year = int_of_string String.(sub year 0 (length year - 1)) in
+            Scheduled (Quarterly (quarter, year))
+        | _ -> failwith ("Failed to parse status: " ^ s))
+
+  let status_to_string = function
+    | Unscheduled -> "Unscheduled"
+    | No_status -> "No Status"
+    | Active -> "Active"
+    | Blocked -> "Blocked"
+    | Unfunded -> "Unfunded"
+    | Scheduled s -> "Scheduled " ^ schedule_to_string s
+
+  type t = {
+    title : string;
+    owner : string option;
+    ident : string;
+    status : status;
+  }
+  [@@deriving yojson]
+
+  let v ~status s =
+    let get_owner_or_ident s =
+      match String.split_on_char ')' s with
+      | "" :: _ -> None
+      | o :: _ -> Some o
+      | _ -> None
+    in
+    let rec aux title = function
+      | [ owner; ident ] ->
+          {
+            title = String.trim (List.rev title |> String.concat "(");
+            owner = get_owner_or_ident owner;
+            ident = get_owner_or_ident ident |> Option.get;
+            status;
+          }
+      | x :: xs -> aux (x :: title) xs
+      | _ -> raise (Failure ("Failed to parse KR: " ^ s))
+    in
+    aux [] (String.split_on_char '(' s)
+end
+
+module Objective = struct
+  type t = { title : string; krs : Kr.t list } [@@deriving yojson]
+
+  let of_block b =
+    let of_paragraph ~status = function
+      | [ Omd.Paragraph ([], Omd.Text ([], kr)) ] -> Kr.v ~status kr
+      | [ Omd.Paragraph ([], Omd.Concat ([], kr)) ] ->
+          Kr.v ~status
+            (Aggregate.inline (Omd.Concat ([], kr)) |> String.concat "")
+      | _ -> failwith ("Expected a paragraph and text: " ^ Omd.to_sexp b)
+    in
+    let of_list ~status = function
+      | Omd.List ([], _, _, lst) -> List.map (of_paragraph ~status) lst
+      | _ -> failwith "Expected a list of paragraphs"
+    in
+    let rec from_headings acc = function
+      | Omd.Heading ([], 3, Omd.Text ([], t)) :: lst :: rest ->
+          from_headings (of_list ~status:(Kr.status_of_string t) lst @ acc) rest
+      | _ -> List.rev acc
+    in
+    match b with
+    | Omd.Heading ([], 2, Omd.Text ([], title)) :: ts ->
+        { title; krs = from_headings [] ts }
+    | _ -> failwith ""
+end
+
+module Project = struct
+  type t = { project : string; objectives : Objective.t list }
+  [@@deriving yojson]
+
+  let of_block b =
+    let rec objectives acc = function
+      | Omd.Heading ([], 2, _) :: xs as t ->
+          objectives (Objective.of_block t :: acc) xs
+      | Omd.Heading ([], 1, _) :: _ | [] -> List.rev acc
+      | _ :: xs -> objectives acc xs
+    in
+    match b with
+    | Omd.Heading ([], 1, Omd.Text ([], project)) :: ts ->
+        { project; objectives = objectives [] ts }
+    | _ -> failwith "Failed to parse project"
+end
+
+type t = Project.t list [@@deriving yojson]
+
+let of_block b =
+  let rec projects acc = function
+    | Omd.Heading ([], 1, _) :: xs as t ->
+        projects (Project.of_block t :: acc) xs
+    | [] -> List.rev acc
+    | _ :: xs -> projects acc xs
+  in
+  projects [] b
+
+(* Flatten OKR structure *)
+module Item = struct
+  type t = { project : string; objective : string; kr : Kr.t }
+  [@@deriving yojson]
+
+  let of_project : Project.t -> t list =
+   fun { project; objectives } ->
+    let of_objective : Objective.t -> t list =
+     fun { title = objective; krs } ->
+      List.map (fun kr -> { project; objective; kr }) krs
+    in
+    let lst = List.map of_objective objectives in
+    List.concat lst
+end

--- a/src/spec.mli
+++ b/src/spec.mli
@@ -1,0 +1,50 @@
+module Kr : sig
+  type schedule = Quarterly of [ `Q1 | `Q2 | `Q3 | `Q4 ] * int | Rolling
+  [@@deriving yojson]
+
+  type status =
+    | Scheduled of schedule
+    | Unscheduled
+    | No_status
+    | Active
+    | Unfunded
+    | Blocked
+  [@@deriving yojson]
+
+  val status_of_string : string -> status
+  val status_to_string : status -> string
+
+  type t = {
+    title : string;
+    owner : string option;
+    ident : string;
+    status : status;
+  }
+  [@@deriving yojson]
+
+  val v : status:status -> string -> t
+end
+
+module Objective : sig
+  type t = { title : string; krs : Kr.t list } [@@deriving yojson]
+
+  val of_block : Omd.doc -> t
+end
+
+module Project : sig
+  type t = { project : string; objectives : Objective.t list }
+  [@@deriving yojson]
+
+  val of_block : Omd.doc -> t
+end
+
+type t = Project.t list [@@deriving yojson]
+
+val of_block : Omd.doc -> t
+
+module Item : sig
+  type t = { project : string; objective : string; kr : Kr.t }
+  [@@deriving yojson]
+
+  val of_project : Project.t -> t list
+end

--- a/src/spec.mli
+++ b/src/spec.mli
@@ -1,5 +1,8 @@
 module Kr : sig
-  type schedule = Quarterly of [ `Q1 | `Q2 | `Q3 | `Q4 ] * int | Rolling
+  type schedule =
+    | Quarterly of [ `Q1 | `Q2 | `Q3 | `Q4 ] * int
+    | Rolling
+    | Unknown
   [@@deriving yojson]
 
   type status =

--- a/test/test.ml
+++ b/test/test.ml
@@ -20,4 +20,5 @@ let () =
       ("Calendar", Test_calendar.tests);
       ("Lint", Test_lint.tests);
       ("Aggregate", Test_aggregate.tests);
+      ("Spec", Test_spec.tests);
     ]

--- a/test/test_spec.ml
+++ b/test/test_spec.ml
@@ -1,5 +1,12 @@
+open Okra
+
 let spec =
   Alcotest.of_pp (fun ppf t -> Yojson.Safe.pp ppf (Okra.Spec.to_yojson t))
+
+let items =
+  Alcotest.of_pp (fun ppf t ->
+      Fmt.pf ppf "%a" (Fmt.list Yojson.Safe.pp)
+        (List.map Okra.Spec.Item.to_yojson t))
 
 let test =
   {|
@@ -22,57 +29,112 @@ let test =
 - Simplify and make it useful (Patrick Ferris) (OKRA4)
 |}
 
+let projects =
+  Spec.
+    {
+      Project.project = "Okra: Objectives";
+      objectives =
+        [
+          Objective.
+            {
+              title = "Release Okra to the World";
+              krs =
+                Kr.
+                  [
+                    {
+                      title = "Add spec parsing to okra";
+                      owner = Some "Patrick Ferris";
+                      ident = "OKRA1";
+                      status = Active;
+                    };
+                    {
+                      title = "Add default work items for projects";
+                      owner = Some "Patrick Ferris";
+                      ident = "OKRA3";
+                      status = Scheduled (Quarterly (`Q3, 2021));
+                    };
+                    {
+                      title = "Calendar bindings for Okra";
+                      owner = Some "Magnus Skjegstad";
+                      ident = "OKRA2";
+                      status = Unscheduled;
+                    };
+                  ];
+            };
+          {
+            title = "Okra Web";
+            krs =
+              [
+                {
+                  title = "Simplify and make it useful";
+                  owner = Some "Patrick Ferris";
+                  ident = "OKRA4";
+                  status = Scheduled (Quarterly (`Q3, 2021));
+                };
+              ];
+          };
+        ];
+    }
+
 let test_spec_parse () =
-  let open Okra in
   let md = Omd.of_string test in
   let actual = Spec.of_block md in
-  let expect =
-    Spec.
-      {
-        Project.project = "Okra: Objectives";
-        objectives =
-          [
-            Objective.
-              {
-                title = "Release Okra to the World";
-                krs =
-                  Kr.
-                    [
-                      {
-                        title = "Add spec parsing to okra";
-                        owner = Some "Patrick Ferris";
-                        ident = "OKRA1";
-                        status = Active;
-                      };
-                      {
-                        title = "Add default work items for projects";
-                        owner = Some "Patrick Ferris";
-                        ident = "OKRA3";
-                        status = Scheduled (Quarterly (`Q3, 2021));
-                      };
-                      {
-                        title = "Calendar bindings for Okra";
-                        owner = Some "Magnus Skjegstad";
-                        ident = "OKRA2";
-                        status = Unscheduled;
-                      };
-                    ];
-              };
-            {
-              title = "Okra Web";
-              krs =
-                [
-                  {
-                    title = "Simplify and make it useful";
-                    owner = Some "Patrick Ferris";
-                    ident = "OKRA4";
-                    status = Scheduled (Quarterly (`Q3, 2021));
-                  };
-                ];
-            };
-          ];
-      }
-  in
-  Alcotest.(check spec) "same spec" [ expect ] actual
+  Alcotest.(check spec) "same spec" [ projects ] actual
 
-let tests = [ ("Parse_spec", `Quick, test_spec_parse) ]
+let test_project_to_items () =
+  let actual = Spec.Item.of_project projects in
+  let expected =
+    [
+      {
+        Okra.Spec.Item.project = "Okra: Objectives";
+        objective = "Release Okra to the World";
+        kr =
+          {
+            Okra.Spec.Kr.title = "Add spec parsing to okra";
+            owner = Some "Patrick Ferris";
+            ident = "OKRA1";
+            status = Okra.Spec.Kr.Active;
+          };
+      };
+      {
+        Okra.Spec.Item.project = "Okra: Objectives";
+        objective = "Release Okra to the World";
+        kr =
+          {
+            Okra.Spec.Kr.title = "Add default work items for projects";
+            owner = Some "Patrick Ferris";
+            ident = "OKRA3";
+            status = Okra.Spec.Kr.Scheduled (Okra.Spec.Kr.Quarterly (`Q3, 2021));
+          };
+      };
+      {
+        Okra.Spec.Item.project = "Okra: Objectives";
+        objective = "Release Okra to the World";
+        kr =
+          {
+            Okra.Spec.Kr.title = "Calendar bindings for Okra";
+            owner = Some "Magnus Skjegstad";
+            ident = "OKRA2";
+            status = Okra.Spec.Kr.Unscheduled;
+          };
+      };
+      {
+        Okra.Spec.Item.project = "Okra: Objectives";
+        objective = "Okra Web";
+        kr =
+          {
+            Okra.Spec.Kr.title = "Simplify and make it useful";
+            owner = Some "Patrick Ferris";
+            ident = "OKRA4";
+            status = Okra.Spec.Kr.Scheduled (Okra.Spec.Kr.Quarterly (`Q3, 2021));
+          };
+      };
+    ]
+  in
+  Alcotest.(check items) "same items" expected actual
+
+let tests =
+  [
+    ("Parse_spec", `Quick, test_spec_parse);
+    ("Spec_items", `Quick, test_project_to_items);
+  ]

--- a/test/test_spec.ml
+++ b/test/test_spec.ml
@@ -1,0 +1,78 @@
+let spec =
+  Alcotest.of_pp (fun ppf t -> Yojson.Safe.pp ppf (Okra.Spec.to_yojson t))
+
+let test =
+  {|
+# Okra: Objectives
+
+## Release Okra to the World
+
+### Active
+- Add spec parsing to okra (Patrick Ferris) (OKRA1)
+
+### Scheduled (Q3 2021)
+- Add default work items for projects (Patrick Ferris) (OKRA3)
+
+### Unscheduled
+- Calendar bindings for Okra (Magnus Skjegstad) (OKRA2)
+
+## Okra Web
+
+### Scheduled (Q3 2021)
+- Simplify and make it useful (Patrick Ferris) (OKRA4)
+|}
+
+let test_spec_parse () =
+  let open Okra in
+  let md = Omd.of_string test in
+  let actual = Spec.of_block md in
+  let expect =
+    Spec.
+      {
+        Project.project = "Okra: Objectives";
+        objectives =
+          [
+            Objective.
+              {
+                title = "Release Okra to the World";
+                krs =
+                  Kr.
+                    [
+                      {
+                        title = "Add spec parsing to okra";
+                        owner = Some "Patrick Ferris";
+                        ident = "OKRA1";
+                        status = Active;
+                      };
+                      {
+                        title = "Add default work items for projects";
+                        owner = Some "Patrick Ferris";
+                        ident = "OKRA3";
+                        status = Scheduled (Quarterly (`Q3, 2021));
+                      };
+                      {
+                        title = "Calendar bindings for Okra";
+                        owner = Some "Magnus Skjegstad";
+                        ident = "OKRA2";
+                        status = Unscheduled;
+                      };
+                    ];
+              };
+            {
+              title = "Okra Web";
+              krs =
+                [
+                  {
+                    title = "Simplify and make it useful";
+                    owner = Some "Patrick Ferris";
+                    ident = "OKRA4";
+                    status = Scheduled (Quarterly (`Q3, 2021));
+                  };
+                ];
+            };
+          ];
+      }
+  in
+  Alcotest.(check spec) "same spec" [ expect ] actual
+
+let tests = [ ("Parse_spec", `Quick, test_spec_parse) ]


### PR DESCRIPTION
I believe the jury is still out on whether or not we should change the format of the SPECs, but if we don't this adds a parser to read the markdown format. The serialisation to json is useful for `okra-web` to expose a REST api. If we want to go down this route I can "undraft" the PR. 