### PR TITLE
time entries should be a multiple of 0.5

### DIFF
--- a/src/aggregate.ml
+++ b/src/aggregate.ml
@@ -99,7 +99,10 @@ let is_time_block = function
   | _ -> false
 
 let time_block_is_sane s =
-  let regexp = Str.regexp "^@[a-zA-Z0-9-]+[ ]+([0-9.]+ day[s]?)$" in
+  let regexp =
+    Str.regexp
+      "^@[a-zA-Z0-9-]+[ ]+(\\(.5\\|[0-9]+\\(.\\(0\\|5\\)\\)?\\) day[s]?)$"
+  in
   let pieces = String.split_on_char ',' (String.trim s) in
   List.for_all
     (fun s ->

--- a/src/lint.ml
+++ b/src/lint.ml
@@ -60,7 +60,8 @@ let string_of_result res =
         s
   | Invalid_time s ->
       Fmt.pf ppf
-        "Invalid time entry found. Format is '- @eng1 (x days), @eng2 (x days)'\n\
+        "Invalid time entry found. Format is '- @eng1 (x days), @eng2 (x days) \
+         where x is multiple of 0.5'\n\
          Error: %s\n"
         s
   | Multiple_time_entries s ->

--- a/test/lint/invalid-time4.rej
+++ b/test/lint/invalid-time4.rej
@@ -1,0 +1,5 @@
+# Title
+
+- This is a KR (KR123)
+  - @eng1 (0.3 days)
+  - My work

--- a/test/lint/invalid-time5.rej
+++ b/test/lint/invalid-time5.rej
@@ -1,0 +1,5 @@
+# Title
+
+- This is a KR (KR123)
+  - @eng1 (4.7 days)
+  - My work

--- a/test/lint/invalid-time6.rej
+++ b/test/lint/invalid-time6.rej
@@ -1,0 +1,5 @@
+# Title
+
+- This is a KR (KR123)
+  - @eng1 ( days)
+  - My work

--- a/test/lint/valid-time1.acc
+++ b/test/lint/valid-time1.acc
@@ -17,5 +17,9 @@
   - My work
 
 - This is a KR (KR124)
-  - @eng1 (0.1 days), @eng1 (.5 day)
+  - @eng1 (0.5 days), @eng1 (.5 day)
+  - My work
+
+- This is a KR (KR124)
+  - @eng1 (15.5 days), @eng1 (.5 day)
   - My work

--- a/test/test_lint.ml
+++ b/test/test_lint.ml
@@ -144,5 +144,8 @@ let tests =
     ("Invalid_time", `Quick, test_invalid_time "./lint/invalid-time1.rej");
     ("Invalid_time", `Quick, test_invalid_time "./lint/invalid-time2.rej");
     ("Invalid_time", `Quick, test_invalid_time "./lint/invalid-time3.rej");
+    ("Invalid_time", `Quick, test_invalid_time "./lint/invalid-time4.rej");
+    ("Invalid_time", `Quick, test_invalid_time "./lint/invalid-time5.rej");
+    ("Invalid_time", `Quick, test_invalid_time "./lint/invalid-time6.rej");
     ("Valid_time", `Quick, test_valid_time "./lint/valid-time1.acc");
   ]


### PR DESCRIPTION
Fixes #30 (I hope...). I'm no regexp expert so maybe there's a nicer way of doing this but the idea is that we accept either `.5` or some number greater than `0` followed by an optional `.0` or `.5` which I think captures everything we want removing the `4.3` cases. 