### PR TITLE
Use applicative syntax for cmdliner

### DIFF
--- a/bin/cat.ml
+++ b/bin/cat.ml
@@ -105,50 +105,34 @@ let run conf =
   in
   Okra.Printer.to_stdout pp okrs
 
+let conf_term =
+  let open Let_syntax_cmdliner in
+  let+ show_time = show_time_term
+  and+ show_time_calc = show_time_calc_term
+  and+ show_engineers = show_engineers_term
+  and+ include_krs = include_krs_term
+  and+ ignore_sections = ignore_sections_term
+  and+ include_sections = include_sections_term in
+  {
+    show_time;
+    show_time_calc;
+    show_engineers;
+    ignore_sections;
+    include_sections;
+    include_krs;
+  }
+
 let term =
-  let cat show_time show_time_calc show_engineers include_krs ignore_sections
-      include_sections team engineer =
-    let conf =
-      if engineer then
-        {
-          show_time;
-          show_time_calc;
-          show_engineers;
-          include_krs;
-          ignore_sections = [];
-          include_sections = [ "Last week" ];
-        }
-      else if team then
-        {
-          show_time;
-          show_time_calc;
-          show_engineers;
-          include_krs;
-          ignore_sections = [ "OKR Updates" ];
-          include_sections = [];
-        }
-      else
-        {
-          show_time;
-          show_time_calc;
-          show_engineers;
-          include_krs;
-          ignore_sections;
-          include_sections;
-        }
-    in
-    run conf
+  let open Let_syntax_cmdliner in
+  let+ conf = conf_term and+ team = team_term and+ engineer = engineer_term in
+  let conf =
+    if engineer then
+      { conf with ignore_sections = []; include_sections = [ "Last week" ] }
+    else if team then
+      { conf with ignore_sections = [ "OKR Updates" ]; include_sections = [] }
+    else conf
   in
-  Term.(
-    const cat
-    $ show_time_term
-    $ show_time_calc_term
-    $ show_engineers_term
-    $ include_krs_term
-    $ ignore_sections_term
-    $ include_sections_term
-    $ team_term
-    $ engineer_term)
+  run conf
 
 let cmd =
   let info =

--- a/bin/let_syntax_cmdliner.ml
+++ b/bin/let_syntax_cmdliner.ml
@@ -1,0 +1,4 @@
+open Cmdliner.Term
+
+let ( let+ ) t f = const f $ t
+let ( and+ ) a b = const (fun x y -> (x, y)) $ a $ b

--- a/bin/let_syntax_cmdliner.mli
+++ b/bin/let_syntax_cmdliner.mli
@@ -1,0 +1,4 @@
+type 'a t := 'a Cmdliner.Term.t
+
+val ( let+ ) : 'a t -> ('a -> 'b) -> 'b t
+val ( and+ ) : 'a t -> 'b t -> ('a * 'b) t

--- a/bin/lint.ml
+++ b/bin/lint.ml
@@ -94,24 +94,23 @@ let run conf =
     Printf.fprintf stderr "Caught unknown error while linting:\n\n";
     raise e
 
+let conf_term =
+  let open Let_syntax_cmdliner in
+  let+ include_sections = include_sections_term
+  and+ ignore_sections = ignore_sections_term
+  and+ files = files_term in
+  { include_sections; ignore_sections; files }
+
 let term =
-  let lint include_sections ignore_sections engineer team files =
-    let conf =
-      if engineer then
-        { include_sections = [ "Last week" ]; ignore_sections = []; files }
-      else if team then
-        { include_sections; ignore_sections = [ "OKR updates" ]; files }
-      else { include_sections; ignore_sections; files }
-    in
-    run conf
+  let open Let_syntax_cmdliner in
+  let+ conf = conf_term and+ engineer = engineer_term and+ team = team_term in
+  let conf =
+    if engineer then
+      { conf with include_sections = [ "Last week" ]; ignore_sections = [] }
+    else if team then { conf with ignore_sections = [ "OKR updates" ] }
+    else conf
   in
-  Term.(
-    const lint
-    $ include_sections_term
-    $ ignore_sections_term
-    $ engineer_term
-    $ team_term
-    $ files_term)
+  run conf
 
 let cmd =
   let info =


### PR DESCRIPTION
This allows using `let+ ... and+ ... in` instead of manually using
`Term.const` and `$`.
