### PR TITLE
add optional footer to conf.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,9 @@ projects:
 locations:
   - "/path/to/admin/dir1"
   - "/path/to/admin/dir2"
+footer: |
+  # Meetings
+  - A recurring meeting
 ```
 
 You can also provide default work items for your projects which are particularly useful for recurring tasks (e.g. meetings). For example: 
@@ -252,4 +255,4 @@ projects:
       - "Documenting the tool"
 ```
 
-There are [mdx tests](test/bin/README.md) which show the output from such a configuration file.
+There are [mdx tests](test/bin/README.md) which show the output from such a configuration file and explain in detail what the different parts do.

--- a/bin/conf.ml
+++ b/bin/conf.ml
@@ -17,9 +17,13 @@ open Okra
 
 let default_project = { Activity.title = "TODO ADD KR (ID)"; items = [] }
 
-type t = { projects : Activity.project list; locations : string list }
+type t = {
+  projects : Activity.project list;
+  locations : string list;
+  footer : string option;
+}
 
-let default = { projects = [ default_project ]; locations = [] }
+let default = { projects = [ default_project ]; locations = []; footer = None }
 let conf_err s = Error (`Msg (Fmt.str "Okra Conf Error: %s" s))
 
 let projects_of_yaml t =
@@ -65,10 +69,12 @@ let of_yaml yaml =
   in
   find "projects" yaml >>= projects_of_yaml >>= fun projects ->
   find "locations" yaml >>= map_option to_string_exn >>= fun locations ->
-  Ok { projects; locations }
+  find "footer" yaml >>| Option.map to_string_exn >>= fun footer ->
+  Ok { projects; locations; footer }
 
 let projects { projects; _ } = projects
 let locations { locations; _ } = locations
+let footer { footer; _ } = footer
 
 let load file =
   let open Rresult in

--- a/bin/conf.mli
+++ b/bin/conf.mli
@@ -26,6 +26,9 @@ val projects : t -> Okra.Activity.project list
 val locations : t -> string list
 (** A list of locations to use when aggregating reports *)
 
+val footer : t -> string option
+(** An optional footer to append to the end of your engineer reports *)
+
 val load : string -> (t, [ `Msg of string ]) result
 (** [load file] attempts to load a configuration from [file] *)
 

--- a/bin/generate.ml
+++ b/bin/generate.ml
@@ -77,7 +77,7 @@ let get_or_error = function
 
 module Fetch = Get_activity.Contributions.Fetch (Cohttp_lwt_unix.Client)
 
-let run cal projects token no_activity =
+let run conf cal projects token no_activity =
   let period = Calendar.github_week cal in
   let week = Calendar.week cal in
   let activity =
@@ -94,8 +94,11 @@ let run cal projects token no_activity =
     Fmt.str "%s week %i: %a -- %a" activity.username week format_date from
       format_date to_
   in
+  let pp_footer ppf conf = Fmt.(pf ppf "\n\n%a" string conf) in
   let activity = Activity.make ~projects activity in
-  Fmt.pr "%s\n\n%a" header Activity.pp activity
+  Fmt.(
+    pr "%s\n\n%a%a" header Activity.pp activity (option pp_footer)
+      (Conf.footer conf))
 
 let term =
   let open Let_syntax_cmdliner in
@@ -114,7 +117,7 @@ let term =
     | false -> Conf.default
     | true -> get_or_error @@ Conf.load okra_file
   in
-  run cal (Conf.projects okra_conf) token no_activity
+  run okra_conf cal (Conf.projects okra_conf) token no_activity
 
 let cmd =
   let info =

--- a/test/bin/README.md
+++ b/test/bin/README.md
@@ -12,6 +12,7 @@ What follows is some brief examples of how to use `okra` to improve the OKR repo
    * [Generating a report](#generating-a-report)
    * [Configuring the tool for your projects](#configuring-the-tool-for-your-projects)
    * [Adding recurring items to your configuration file](#adding-recurring-items-to-your-configuration-file)
+   * [Adding a footer to your report](#adding-a-footer-to-your-report)
    * [Linting your weekly report](#linting-your-weekly-report)
 
 ## Engineers
@@ -128,6 +129,50 @@ $ okra generate --week=37 --year=2021 --no-activity --conf=conf.projects.yaml
 
 
 ```
+
+### Adding a footer to your report
+
+Sometimes you might have some recurring comments to make outside of last week's activity (perhaps meetings and the like). You can add a `footer` section to your configuration file which simply appends the string to the end of your report. 
+
+<!-- $MDX dir=files -->
+```sh
+$ cat conf.footer.yaml
+projects:
+  - "Make Okra, the OKR management tool (OKR1)"
+  - "Make a web interface for Okra (OKR2)"
+footer: |
+  # Meetings
+  - A meeting with x, y and z
+  - Another thing as well
+$ okra generate --week=37 --year=2021 --no-activity --conf=conf.footer.yaml
+<USERNAME> week 37: 2021/09/13 -- 2021/09/19
+
+# Projects
+
+- Make Okra, the OKR management tool (OKR1)
+- Make a web interface for Okra (OKR2)
+
+# Last Week
+
+- Make Okra, the OKR management tool (OKR1)
+  - @<USERNAME> (<X> days)
+  - Work Item 1
+
+- Make a web interface for Okra (OKR2)
+  - @<USERNAME> (<X> days)
+  - Work Item 1
+
+# Activity (move these items to last week)
+
+
+
+
+# Meetings
+- A meeting with x, y and z
+- Another thing as well
+```
+
+The vast space between `Activity` and `Meetings` is just an artefact of `--no-activity`. Note the `|` which tells yaml to include the newlines and any trailing spaces.
 
 ### Linting your weekly report
 

--- a/test/bin/files/conf.footer.yaml
+++ b/test/bin/files/conf.footer.yaml
@@ -1,0 +1,7 @@
+projects:
+  - "Make Okra, the OKR management tool (OKR1)"
+  - "Make a web interface for Okra (OKR2)"
+footer: |
+  # Meetings
+  - A meeting with x, y and z
+  - Another thing as well


### PR DESCRIPTION
This PR adds an optional footer to the configuration file that will be printed to the bottom of the engineer reports. Hopefully this fixes #34. An example is given in the mdx tests: https://github.com/patricoferris/okra-1/blob/c6b09a6e65fae5ed75ccc0d969576aa09c5a4f09/test/bin/README.md#adding-a-footer-to-your-report