### PR TITLE
Add cat support for OKR database

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -33,5 +33,6 @@
   fmt
   get-activity
   calendar
+  csv
   (omd (>= 2.0))))
 (using mdx 0.1)

--- a/okra.opam
+++ b/okra.opam
@@ -13,6 +13,7 @@ depends: [
   "fmt"
   "get-activity"
   "calendar"
+  "csv"
   "omd" {>= "2.0"}
   "odoc" {with-doc}
 ]

--- a/src/KR.ml
+++ b/src/KR.ml
@@ -190,6 +190,28 @@ let make_time_entries t =
   let aux (e, d) = Fmt.strf "@%s (%s)" e (string_of_days d) in
   Item.[ Paragraph (Text (String.concat ", " (List.map aux t))) ]
 
+let update_from_master_db t db =
+  let update (orig_kr : t) (db_kr : Masterdb.elt_t option) =
+    match db_kr with
+    | None -> orig_kr
+    | Some db_kr ->
+        {
+          orig_kr with
+          id = Some db_kr.id;
+          title = db_kr.title;
+          objective = db_kr.objective;
+          project = db_kr.project;
+        }
+  in
+
+  match t.id with
+  | None ->
+      let db_kr = Masterdb.find_title_opt db t.title in
+      update t db_kr
+  | Some id ->
+      let db_kr = Masterdb.find_kr_opt db id in
+      update t db_kr
+
 let items conf kr =
   let open Item in
   if

--- a/src/KR.ml
+++ b/src/KR.ml
@@ -195,6 +195,26 @@ let update_from_master_db t db =
     match db_kr with
     | None -> orig_kr
     | Some db_kr ->
+        if orig_kr.id = None then
+          Log.warn (fun l ->
+              l "KR ID updated from unspecified to %S :\n- %S\n- %S" db_kr.id
+                orig_kr.title db_kr.title);
+        if orig_kr.title <> db_kr.title then
+          Log.warn (fun l ->
+              l "Title for KR %S does not match title in database:\n- %S\n- %S"
+                db_kr.id orig_kr.title db_kr.title);
+        if orig_kr.objective <> db_kr.objective then
+          Log.warn (fun l ->
+              l
+                "Objective for KR %S does not match objective in database:\n\
+                 - %S\n\
+                 - %S" db_kr.id orig_kr.objective db_kr.objective);
+        if orig_kr.project <> db_kr.project then
+          Log.warn (fun l ->
+              l
+                "Project for KR %S does not match project in database:\n\
+                 - %S\n\
+                 - %S" db_kr.id orig_kr.project db_kr.project);
         {
           orig_kr with
           id = Some db_kr.id;

--- a/src/KR.mli
+++ b/src/KR.mli
@@ -39,6 +39,7 @@ val v :
 val dump : t Fmt.t
 val merge : t -> t -> t
 val compare : t -> t -> int
+val update_from_master_db : t -> Masterdb.t -> t
 
 type config = {
   show_engineers : bool;

--- a/src/dune
+++ b/src/dune
@@ -1,4 +1,4 @@
 (library
  (name okra)
  (public_name okra)
- (libraries logs omd fmt str calendar get-activity))
+ (libraries logs omd fmt str calendar csv get-activity))

--- a/src/masterdb.ml
+++ b/src/masterdb.ml
@@ -1,0 +1,122 @@
+(*
+ * Copyright (c) 2021 Magnus Skjegstad <magnus@skjegstad.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+exception Missing_ID of int * string
+exception Duplicate_ID of int * string
+exception Missing_objective of int * string
+exception Missing_project of int * string
+exception Missing_title of int * string
+exception KR_not_found of string
+
+type cat_t = Commercial | Community
+
+type status_t =
+  | Active
+  | Dropped
+  | Complete
+  | Scheduled
+  | Unscheduled
+  | Wontfix
+
+type elt_t = {
+  id : string;
+  title : string;
+  objective : string;
+  project : string;
+  schedule : string;
+  lead : string;
+  team : string;
+  category : string;
+  status : status_t option;
+}
+
+type t = (string, elt_t) Hashtbl.t
+
+let status_of_string s =
+  match String.uppercase_ascii s with
+  | "ACTIVE" -> Some Active
+  | "DROPPED" -> Some Dropped
+  | "COMPLETE" -> Some Complete
+  | "SCHEDULED" -> Some Scheduled
+  | "UNSCHEDULED" -> Some Unscheduled
+  | "WONTFIX" -> Some Wontfix
+  | _ -> None
+
+let empty_db = Hashtbl.create 13
+
+let load_csv ?(separator = ',') f =
+  let res = empty_db in
+  let line = ref 1 in
+  let ic = open_in f in
+  try
+    let rows = Csv.of_channel ~separator ~has_header:true ic in
+    Csv.Rows.iter
+      ~f:(fun row ->
+        line := !line + 1;
+        let find_and_trim col = Csv.Row.find row col |> String.trim in
+        let e =
+          {
+            id = find_and_trim "id" |> String.uppercase_ascii;
+            title = find_and_trim "title";
+            objective = find_and_trim "objective";
+            project = find_and_trim "project";
+            schedule = find_and_trim "schedule";
+            lead = find_and_trim "lead";
+            team = find_and_trim "team";
+            category = find_and_trim "category";
+            status = find_and_trim "status" |> status_of_string;
+          }
+        in
+        if e.id = "" then
+          raise (Missing_ID (!line, "A unique KR ID is required per line"));
+        if Hashtbl.mem res e.id then
+          raise
+            (Duplicate_ID (!line, Fmt.str "KR ID \"%s\" is not unique." e.id));
+        if e.title = "" then
+          raise
+            (Missing_title
+               (!line, Fmt.str "KR ID \"%s\" does not have a title" e.id));
+        if e.objective = "" then
+          raise
+            (Missing_objective
+               ( !line,
+                 Fmt.str "KR ID \"%s\" does is not part of an objective" e.id ));
+        if e.project = "" then
+          raise
+            (Missing_project
+               (!line, Fmt.str "KR ID \"%s\" does is not part of a project" e.id));
+        Hashtbl.add res e.id e)
+      rows;
+    res
+  with e ->
+    close_in_noerr ic;
+    raise e
+
+let find_kr_opt t id = Hashtbl.find_opt t (id |> String.uppercase_ascii)
+
+let find_kr t id =
+  match find_kr_opt t id with None -> raise (KR_not_found id) | Some x -> x
+
+let has_kr t id = Hashtbl.mem t (id |> String.uppercase_ascii)
+
+let find_title_opt t title =
+  Printf.printf "matching %s\n" title;
+  let title_no_case = title |> String.uppercase_ascii |> String.trim in
+  let okrs = Hashtbl.to_seq_values t |> List.of_seq in
+  List.find_opt
+    (fun kr ->
+      kr.title |> String.uppercase_ascii |> String.trim = title_no_case)
+    okrs

--- a/src/masterdb.mli
+++ b/src/masterdb.mli
@@ -1,0 +1,52 @@
+(*
+ * Copyright (c) 2021 Magnus Skjegstad <magnus@skjegstad.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+exception Missing_ID of int * string
+exception Duplicate_ID of int * string
+exception Missing_objective of int * string
+exception Missing_project of int * string
+exception Missing_title of int * string
+exception KR_not_found of string
+
+type cat_t = Commercial | Community
+
+type status_t =
+  | Active
+  | Dropped
+  | Complete
+  | Scheduled
+  | Unscheduled
+  | Wontfix
+
+type elt_t = private {
+  id : string;
+  title : string;
+  objective : string;
+  project : string;
+  schedule : string;
+  lead : string;
+  team : string;
+  category : string;
+  status : status_t option;
+}
+
+type t = (string, elt_t) Hashtbl.t
+
+val load_csv : ?separator:char -> string -> t
+val find_kr_opt : t -> string -> elt_t option
+val find_kr : t -> string -> elt_t
+val find_title_opt : t -> string -> elt_t option
+val has_kr : t -> string -> bool

--- a/src/parser.mli
+++ b/src/parser.mli
@@ -1,5 +1,5 @@
 (*
- * Copyright (c) 2021 Magnus Skjegstad
+ * Copyright (c) 2021 Magnus Skjegstad <magnus@skjegstad.com>
  * Copyright (c) 2021 Thomas Gazagnaire <thomas@gazagnaire.org>
  *
  * Permission to use, copy, modify, and distribute this software for any

--- a/src/report.mli
+++ b/src/report.mli
@@ -41,13 +41,14 @@ module Objective : sig
 end
 
 val dump : t Fmt.t
-val of_krs : KR.t list -> t
+val of_krs : ?okr_db:Masterdb.t -> KR.t list -> t
 val of_projects : project list -> t
 val of_objectives : project:string -> objective list -> t
 
 val of_markdown :
   ?ignore_sections:string list ->
   ?include_sections:string list ->
+  ?okr_db:Masterdb.t ->
   Parser.markdown ->
   t
 
@@ -59,7 +60,7 @@ val iter :
   unit
 
 val find : t -> ?title:string -> ?id:string -> unit -> KR.t list
-val add : t -> KR.t -> unit
+val add : ?okr_db:Masterdb.t -> t -> KR.t -> unit
 
 val pp :
   ?include_krs:string list ->

--- a/test/pp/db.csv
+++ b/test/pp/db.csv
@@ -1,0 +1,2 @@
+project,id,title,objective
+Project A,KR123,Title A,Objective A

--- a/test/pp/dune
+++ b/test/pp/dune
@@ -5,6 +5,21 @@
 
 (rule
  (deps
+  (:file1 use_db.md)
+  (:file2 db.csv))
+ (action
+  (with-stdout-to
+   use_db.md.pp
+   (run ./test.exe --use-db %{file1}))))
+
+(rule
+ (alias runtest)
+ (package okra)
+ (action
+  (diff use_db_replaced.md use_db.md.pp)))
+
+(rule
+ (deps
   (:file eng1.md))
  (action
   (with-stdout-to

--- a/test/pp/use_db.md
+++ b/test/pp/use_db.md
@@ -1,0 +1,6 @@
+# Test
+
+- This is a KR with the wrong name (KR123)
+  - @engineer1 (1 day)
+  - work 1
+  - work 2

--- a/test/pp/use_db_replaced.md
+++ b/test/pp/use_db_replaced.md
@@ -1,0 +1,8 @@
+# Project A
+
+## Objective A
+
+- Title A (KR123)
+  - @engineer1 (1 day)
+  - work 1
+  - work 2


### PR DESCRIPTION
Adds support for an optional OKR database provided as a CSV-file.

Initially also adds support in `cat` for an optional `--okr-db`
parameter. When provided, titles, objectives and projects will be
overwritten in the report with data from the database. If no KR ID is
available the title will be used to look it up in the db.