### PR TITLE
lint: add machine readable output

### DIFF
--- a/src/lint.ml
+++ b/src/lint.ml
@@ -132,3 +132,38 @@ let lint ?(include_sections = []) ?(ignore_sections = []) ic =
       (Format_error
          (List.sort (fun (x, _) (y, _) -> compare x y) !format_errors))
   else check_document ~include_sections ~ignore_sections s
+
+let short_messages_of_error file_name =
+  let short_message line_number msg =
+    [ Printf.sprintf "%s:%d:%s" file_name line_number msg ]
+  in
+  let short_messagef line_number fmt =
+    Printf.ksprintf (short_message line_number) fmt
+  in
+  function
+  | Format_error errs ->
+      List.concat_map
+        (fun (line_number, message) -> short_message line_number message)
+        errs
+  | No_time_found kr ->
+      let line_number = 1 in
+      short_messagef line_number "No time found in %S" kr
+  | Invalid_time kr ->
+      let line_number = 1 in
+      short_messagef line_number "Invalid time in %S" kr
+  | Multiple_time_entries kr ->
+      let line_number = 1 in
+      short_messagef line_number "Multiple time entries for %S" kr
+  | No_work_found kr ->
+      let line_number = 1 in
+      short_messagef line_number "No work found for %S" kr
+  | No_KR_ID_found kr ->
+      let line_number = 1 in
+      short_messagef line_number "No KR ID found for %S" kr
+  | No_project_found kr ->
+      let line_number = 1 in
+      short_messagef line_number "No project found for %S" kr
+  | Not_all_includes l ->
+      let line_number = 1 in
+      short_messagef line_number "Missing includes section: %s"
+        (String.concat ", " l)

--- a/src/lint.ml
+++ b/src/lint.ml
@@ -17,12 +17,12 @@
 
 type lint_error =
   | Format_error of (int * string) list
-  | No_time_found of string
-  | Invalid_time of string
-  | Multiple_time_entries of string
-  | No_work_found of string
-  | No_KR_ID_found of string
-  | No_project_found of string
+  | No_time_found of int option * string
+  | Invalid_time of int option * string
+  | Multiple_time_entries of int option * string
+  | No_work_found of int option * string
+  | No_KR_ID_found of int option * string
+  | No_project_found of int option * string
   | Not_all_includes of string list
 
 type lint_result = (unit, lint_error) result
@@ -51,37 +51,37 @@ let pp_error ppf = function
       List.iter (fun (pos, msg) -> Fmt.pf ppf "Line %d: %s\n" pos msg) x;
       Fmt.pf ppf "%d formatting errors found. Parsing aborted.\n"
         (List.length x)
-  | No_time_found s ->
+  | No_time_found (_, s) ->
       Fmt.pf ppf
         "In KR %S:\n\
         \  No time entry found. Each KR must be followed by '- @@... (x days)'\n"
         s
-  | Invalid_time s ->
+  | Invalid_time (_, s) ->
       Fmt.pf ppf
         "In KR %S:\n\
         \  Invalid time entry found. Format is '- @@eng1 (x days), @@eng2 (x \
          days)'\n"
         s
-  | Multiple_time_entries s ->
+  | Multiple_time_entries (_, s) ->
       Fmt.pf ppf
         "In KR %S:\n\
         \  Multiple time entries found. Only one time entry should follow \
          immediately after the KR.\n"
         s
-  | No_work_found s ->
+  | No_work_found (_, s) ->
       Fmt.pf ppf
         "In KR %S:\n\
         \  No work items found. This may indicate an unreported parsing error. \
          Remove the KR if it is without work.\n"
         s
-  | No_KR_ID_found s ->
+  | No_KR_ID_found (_, s) ->
       Fmt.pf ppf
         "In KR %S:\n\
         \  No KR ID found. KRs should be in the format \"This is a KR \
          (PLAT123)\", where PLAT123 is the KR ID. For KRs that don't have an \
          ID yet, use \"New KR\" and for work without a KR use \"No KR\".\n"
         s
-  | No_project_found s ->
+  | No_project_found (_, s) ->
       Fmt.pf ppf "In KR %S:\n  No project found (starting with '#')\n" s
   | Not_all_includes s ->
       Fmt.pf ppf "Missing includes section: %a\n" Fmt.(list ~sep:comma string) s
@@ -96,21 +96,31 @@ let check_line line pos =
       if Str.string_match regexp line 0 then (pos, msg) :: acc else acc)
     [] fail_fmt_patterns
 
+let grep_n s lines =
+  let re = Str.regexp_case_fold (".*" ^ Str.quote s ^ ".*") in
+  List.find_map
+    (fun (i, line) -> if Str.string_match re line 0 then Some i else None)
+    lines
+
 (* Parse document as a string to check for aggregation errors
    (assumes no formatting errors) *)
 let check_document ~include_sections ~ignore_sections s =
+  let lines =
+    String.split_on_char '\n' s |> List.mapi (fun i s -> (i + 1, s))
+  in
   try
     let md = Omd.of_string s in
     let okrs = Parser.of_markdown ~include_sections ~ignore_sections md in
     let _report = Report.of_krs okrs in
     Ok ()
   with
-  | Parser.No_time_found s -> Error (No_time_found s)
-  | Parser.Invalid_time s -> Error (Invalid_time s)
-  | Parser.Multiple_time_entries s -> Error (Multiple_time_entries s)
-  | Parser.No_work_found s -> Error (No_work_found s)
-  | Parser.No_KR_ID_found s -> Error (No_KR_ID_found s)
-  | Parser.No_project_found s -> Error (No_project_found s)
+  | Parser.No_time_found s -> Error (No_time_found (grep_n s lines, s))
+  | Parser.Invalid_time s -> Error (Invalid_time (grep_n s lines, s))
+  | Parser.Multiple_time_entries s ->
+      Error (Multiple_time_entries (grep_n s lines, s))
+  | Parser.No_work_found s -> Error (No_work_found (grep_n s lines, s))
+  | Parser.No_KR_ID_found s -> Error (No_KR_ID_found (grep_n s lines, s))
+  | Parser.No_project_found s -> Error (No_project_found (grep_n s lines, s))
   | Parser.Not_all_includes_accounted_for s -> Error (Not_all_includes s)
 
 let lint ?(include_sections = []) ?(ignore_sections = []) ic =
@@ -137,7 +147,8 @@ let short_messages_of_error file_name =
   let short_message line_number msg =
     [ Printf.sprintf "%s:%d:%s" file_name line_number msg ]
   in
-  let short_messagef line_number fmt =
+  let short_messagef line_number_opt fmt =
+    let line_number = Option.value ~default:1 line_number_opt in
     Printf.ksprintf (short_message line_number) fmt
   in
   function
@@ -145,25 +156,17 @@ let short_messages_of_error file_name =
       List.concat_map
         (fun (line_number, message) -> short_message line_number message)
         errs
-  | No_time_found kr ->
-      let line_number = 1 in
+  | No_time_found (line_number, kr) ->
       short_messagef line_number "No time found in %S" kr
-  | Invalid_time kr ->
-      let line_number = 1 in
+  | Invalid_time (line_number, kr) ->
       short_messagef line_number "Invalid time in %S" kr
-  | Multiple_time_entries kr ->
-      let line_number = 1 in
+  | Multiple_time_entries (line_number, kr) ->
       short_messagef line_number "Multiple time entries for %S" kr
-  | No_work_found kr ->
-      let line_number = 1 in
+  | No_work_found (line_number, kr) ->
       short_messagef line_number "No work found for %S" kr
-  | No_KR_ID_found kr ->
-      let line_number = 1 in
+  | No_KR_ID_found (line_number, kr) ->
       short_messagef line_number "No KR ID found for %S" kr
-  | No_project_found kr ->
-      let line_number = 1 in
+  | No_project_found (line_number, kr) ->
       short_messagef line_number "No project found for %S" kr
   | Not_all_includes l ->
-      let line_number = 1 in
-      short_messagef line_number "Missing includes section: %s"
-        (String.concat ", " l)
+      short_messagef None "Missing includes section: %s" (String.concat ", " l)

--- a/src/lint.mli
+++ b/src/lint.mli
@@ -34,3 +34,4 @@ val lint :
   lint_result
 
 val string_of_error : lint_error -> string
+val short_messages_of_error : string -> lint_error -> string list

--- a/src/lint.mli
+++ b/src/lint.mli
@@ -17,12 +17,12 @@
 
 type lint_error =
   | Format_error of (int * string) list
-  | No_time_found of string
-  | Invalid_time of string
-  | Multiple_time_entries of string
-  | No_work_found of string
-  | No_KR_ID_found of string
-  | No_project_found of string
+  | No_time_found of int option * string
+  | Invalid_time of int option * string
+  | Multiple_time_entries of int option * string
+  | No_work_found of int option * string
+  | No_KR_ID_found of int option * string
+  | No_project_found of int option * string
   | Not_all_includes of string list
 
 type lint_result = (unit, lint_error) result

--- a/syntax_checkers/markdown/okra.vim
+++ b/syntax_checkers/markdown/okra.vim
@@ -1,0 +1,25 @@
+if exists('g:loaded_syntastic_markdown_okra')
+    finish
+endif
+let g:loaded_syntastic_markdown_okra = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_markdown_okra_GetLocList() dict
+    let makeprg = self.makeprgBuild({'args': ['lint', '--short']})
+
+    let errorformat = '%f:%l:%m'
+
+    return SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat,
+        \ 'returns': [0, 1]})
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'markdown',
+    \ 'name': 'okra'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo

--- a/test/bin/README.md
+++ b/test/bin/README.md
@@ -200,7 +200,7 @@ $ cat bactrian.bad.md
   - @bactrian (3 days)
   - wrote some html
 $ okra lint --engineer bactrian.bad.md
-[ERROR(S)]: file bactrian.bad.md
+[ERROR(S)]: bactrian.bad.md
 
 In KR "Make Okra, the OKR management tool":
   No time entry found. Each KR must be followed by '- @... (x days)'
@@ -225,7 +225,7 @@ $ cat bactrian.good.md
   - @bactrian (3 days)
   - wrote some html
 $ okra lint --engineer bactrian.good.md
-[OK]: file bactrian.good.md
+[OK]: bactrian.good.md
 ```
 
 ## Team Leads

--- a/test/cram/lint/engineer.t
+++ b/test/cram/lint/engineer.t
@@ -29,7 +29,7 @@ This is a valid one:
   > 
   > More unformatted text.
   > EOF
-  [OK]: input stream
+  [OK]: <stdin>
 
 Errors in include section are detected even if the rest is ignored.
 
@@ -51,7 +51,7 @@ Errors in include section are detected even if the rest is ignored.
   > 
   > More unformatted text.
   > EOF
-  [ERROR(S)]: input stream
+  [ERROR(S)]: <stdin>
   
   In KR "This is a KR (KRID)":
     No time entry found. Each KR must be followed by '- @... (x days)'
@@ -77,7 +77,7 @@ Only "No KR" and "New KR" are supported for KR's without identifiers
   > 
   > More unformatted text.
   > EOF
-  [ERROR(S)]: input stream
+  [ERROR(S)]: <stdin>
   
   In KR "This is a KR (Off KR)":
     No KR ID found. KRs should be in the format "This is a KR (PLAT123)", where PLAT123 is the KR ID. For KRs that don't have an ID yet, use "New KR" and for work without a KR use "No KR".

--- a/test/cram/lint/errors.t
+++ b/test/cram/lint/errors.t
@@ -10,7 +10,7 @@ No KR ID found:
   >   - @eng1 (1 day)
   >   - My work
   > EOF
-  [ERROR(S)]: input stream
+  [ERROR(S)]: <stdin>
   
   In KR "This is a KR":
     No KR ID found. KRs should be in the format "This is a KR (PLAT123)", where PLAT123 is the KR ID. For KRs that don't have an ID yet, use "New KR" and for work without a KR use "No KR".
@@ -21,7 +21,7 @@ No KR ID found:
   >   - @eng1 (1 day)
   >   - My work
   > EOF
-  [ERROR(S)]: input stream
+  [ERROR(S)]: <stdin>
   
   In KR "This is a KR":
     No project found (starting with '#')
@@ -35,7 +35,7 @@ No work items found:
   > - This is a KR (KRID)
   >   - @eng1 (1 day)
   > EOF
-  [ERROR(S)]: input stream
+  [ERROR(S)]: <stdin>
   
   In KR "This is a KR (KRID)":
     No work items found. This may indicate an unreported parsing error. Remove the KR if it is without work.
@@ -50,7 +50,7 @@ No time entry found:
   >   - My work
   >   - @eng1 (1 day)
   > EOF
-  [ERROR(S)]: input stream
+  [ERROR(S)]: <stdin>
   
   In KR "This is a KR":
     No time entry found. Each KR must be followed by '- @... (x days)'
@@ -67,7 +67,7 @@ Multiple time entries:
   >   - @eng2 (2 days)
   >   - More work
   > EOF
-  [ERROR(S)]: input stream
+  [ERROR(S)]: <stdin>
   
   In KR "This is a KR":
     Multiple time entries found. Only one time entry should follow immediately after the KR.
@@ -75,39 +75,168 @@ Multiple time entries:
 
 Format errors
 
-  $ okra lint << EOF
+  $ cat > err-bullet.md << EOF
   > # Title
   > 
   > - This is a KR (KRID)
   >   - @eng1 (1 day)
   >   + My work
   > EOF
-  [ERROR(S)]: input stream
+  $ okra lint err-bullet.md
+  [ERROR(S)]: err-bullet.md
   
   Line 5: + used as bullet point, this can confuse the parser. Only use - as bullet marker.
   1 formatting errors found. Parsing aborted.
   [1]
-  $ okra lint << EOF
+  $ okra lint --short < err-bullet.md
+  <stdin>:5:+ used as bullet point, this can confuse the parser. Only use - as bullet marker.
+  [1]
+  $ cat > err-space-title.md << EOF
   >  # Title
   > 
   > - This is a KR (KRID)
   >   - @eng1 (1 day)
   >   - My work
   > EOF
-  [ERROR(S)]: input stream
+  $ okra lint err-space-title.md
+  [ERROR(S)]: err-space-title.md
   
   Line 1: Space found before title marker #. Start titles in first column.
   1 formatting errors found. Parsing aborted.
   [1]
-  $ okra lint << EOF
+  $ okra lint --short err-space-title.md
+  err-space-title.md:1:Space found before title marker #. Start titles in first column.
+  [1]
+
+  $ cat > err-space-indent.md << EOF
   > # Title
   > 
   >  - This is a KR (KRID)
   >   - @eng1 (1 day)
   >   - My work
   > EOF
-  [ERROR(S)]: input stream
+  $ okra lint err-space-indent.md
+  [ERROR(S)]: err-space-indent.md
   
   Line 3: Single space used for indentation (' - text'). Remove or replace by 2 or more spaces.
   1 formatting errors found. Parsing aborted.
+  [1]
+  $ okra lint --short err-space-indent.md
+  err-space-indent.md:3:Single space used for indentation (' - text'). Remove or replace by 2 or more spaces.
+  [1]
+
+  $ cat > err-no-time.md << EOF
+  > # Last week
+  > 
+  > - Everything is great (E1)
+  >   - Did everything
+  > EOF
+  $ okra lint err-no-time.md
+  [ERROR(S)]: err-no-time.md
+  
+  In KR "Everything is great":
+    No time entry found. Each KR must be followed by '- @... (x days)'
+  [1]
+  $ okra lint --short err-no-time.md
+  err-no-time.md:1:No time found in "Everything is great"
+  [1]
+
+  $ cat > err-invalid-time.md << EOF
+  > # Last week
+  > 
+  > - Everything is great (E1)
+  >   - @a (day)
+  >   - Did everything
+  > EOF
+  $ okra lint err-invalid-time.md
+  [ERROR(S)]: err-invalid-time.md
+  
+  In KR "@a (day)":
+    Invalid time entry found. Format is '- @eng1 (x days), @eng2 (x days)'
+  [1]
+  $ okra lint --short err-invalid-time.md
+  err-invalid-time.md:1:Invalid time in "@a (day)"
+  [1]
+
+  $ cat > err-multiple-time.md << EOF
+  > # Last week
+  > 
+  > - Everything is great (E1)
+  >   - @a (1 day)
+  >   - @a (1 day)
+  >   - Did everything
+  > EOF
+  $ okra lint err-multiple-time.md
+  [ERROR(S)]: err-multiple-time.md
+  
+  In KR "Everything is great":
+    Multiple time entries found. Only one time entry should follow immediately after the KR.
+  [1]
+  $ okra lint --short err-multiple-time.md
+  err-multiple-time.md:1:Multiple time entries for "Everything is great"
+  [1]
+
+  $ cat > err-no-work.md << EOF
+  > # Last week
+  > 
+  > - Everything is great (E1)
+  >   - @a (1 day)
+  > EOF
+  $ okra lint err-no-work.md
+  [ERROR(S)]: err-no-work.md
+  
+  In KR "Everything is great":
+    No work items found. This may indicate an unreported parsing error. Remove the KR if it is without work.
+  [1]
+  $ okra lint --short err-no-work.md
+  err-no-work.md:1:No work found for "Everything is great"
+  [1]
+
+  $ cat > err-no-kr-id.md << EOF
+  > # Last week
+  > 
+  > - Everything is great
+  >   - @a (1 day)
+  >   - Did everything
+  > EOF
+  $ okra lint err-no-kr-id.md
+  [ERROR(S)]: err-no-kr-id.md
+  
+  In KR "Everything is great":
+    No KR ID found. KRs should be in the format "This is a KR (PLAT123)", where PLAT123 is the KR ID. For KRs that don't have an ID yet, use "New KR" and for work without a KR use "No KR".
+  [1]
+  $ okra lint --short err-no-kr-id.md
+  err-no-kr-id.md:1:No KR ID found for "Everything is great"
+  [1]
+
+  $ cat > err-no-project.md << EOF
+  > - Everything is great (E1)
+  >   - @a (1 day)
+  >   - Did everything
+  > EOF
+  $ okra lint err-no-project.md
+  [ERROR(S)]: err-no-project.md
+  
+  In KR "Everything is great":
+    No project found (starting with '#')
+  [1]
+  $ okra lint --short err-no-project.md
+  err-no-project.md:1:No project found for "Everything is great"
+  [1]
+
+  $ cat > err-not-all-includes.md << EOF
+  > # Section
+  > 
+  > - Everything is great (E1)
+  >   - @a (1 day)
+  >   - Did everything
+  > EOF
+  $ okra lint --include-sections "Section A,Section B" err-not-all-includes.md
+  [ERROR(S)]: err-not-all-includes.md
+  
+  Missing includes section: SECTION B,
+  SECTION A
+  [1]
+  $ okra lint --include-sections "Section A,Section B" --short err-not-all-includes.md
+  err-not-all-includes.md:1:Missing includes section: SECTION B, SECTION A
   [1]

--- a/test/cram/lint/errors.t
+++ b/test/cram/lint/errors.t
@@ -138,7 +138,7 @@ Format errors
     No time entry found. Each KR must be followed by '- @... (x days)'
   [1]
   $ okra lint --short err-no-time.md
-  err-no-time.md:1:No time found in "Everything is great"
+  err-no-time.md:3:No time found in "Everything is great"
   [1]
 
   $ cat > err-invalid-time.md << EOF
@@ -155,7 +155,7 @@ Format errors
     Invalid time entry found. Format is '- @eng1 (x days), @eng2 (x days)'
   [1]
   $ okra lint --short err-invalid-time.md
-  err-invalid-time.md:1:Invalid time in "@a (day)"
+  err-invalid-time.md:4:Invalid time in "@a (day)"
   [1]
 
   $ cat > err-multiple-time.md << EOF
@@ -173,7 +173,7 @@ Format errors
     Multiple time entries found. Only one time entry should follow immediately after the KR.
   [1]
   $ okra lint --short err-multiple-time.md
-  err-multiple-time.md:1:Multiple time entries for "Everything is great"
+  err-multiple-time.md:3:Multiple time entries for "Everything is great"
   [1]
 
   $ cat > err-no-work.md << EOF
@@ -189,7 +189,7 @@ Format errors
     No work items found. This may indicate an unreported parsing error. Remove the KR if it is without work.
   [1]
   $ okra lint --short err-no-work.md
-  err-no-work.md:1:No work found for "Everything is great"
+  err-no-work.md:3:No work found for "Everything is great"
   [1]
 
   $ cat > err-no-kr-id.md << EOF
@@ -206,7 +206,7 @@ Format errors
     No KR ID found. KRs should be in the format "This is a KR (PLAT123)", where PLAT123 is the KR ID. For KRs that don't have an ID yet, use "New KR" and for work without a KR use "No KR".
   [1]
   $ okra lint --short err-no-kr-id.md
-  err-no-kr-id.md:1:No KR ID found for "Everything is great"
+  err-no-kr-id.md:3:No KR ID found for "Everything is great"
   [1]
 
   $ cat > err-no-project.md << EOF

--- a/test/cram/lint/features.t
+++ b/test/cram/lint/features.t
@@ -7,7 +7,7 @@ Lint can read from a file:
   >   - Do it
   > EOF
   $ okra lint err.md
-  [ERROR(S)]: file err.md
+  [ERROR(S)]: err.md
   
   In KR "Everything is great":
     No time entry found. Each KR must be followed by '- @... (x days)'
@@ -16,7 +16,7 @@ Lint can read from a file:
 It can also read from stdin:
 
   $ okra lint < err.md
-  [ERROR(S)]: input stream
+  [ERROR(S)]: <stdin>
   
   In KR "Everything is great":
     No time entry found. Each KR must be followed by '- @... (x days)'
@@ -33,9 +33,9 @@ If everything is fine, nothing is printed and it exits with 0:
   > EOF
 
   $ okra lint ok.md
-  [OK]: file ok.md
+  [OK]: ok.md
   $ okra lint < ok.md
-  [OK]: input stream
+  [OK]: <stdin>
 
 When errors are found in several files, they are all printed:
 
@@ -47,11 +47,11 @@ When errors are found in several files, they are all printed:
   >   - Do it
   > EOF
   $ okra lint err.md err2.md
-  [ERROR(S)]: file err.md
+  [ERROR(S)]: err.md
   
   In KR "Everything is great":
     No time entry found. Each KR must be followed by '- @... (x days)'
-  [ERROR(S)]: file err2.md
+  [ERROR(S)]: err2.md
   
   In KR "@a":
     Invalid time entry found. Format is '- @eng1 (x days), @eng2 (x days)'

--- a/test/cram/lint/includes.t
+++ b/test/cram/lint/includes.t
@@ -21,7 +21,7 @@ Missing include sections are errors, for engineer reports this is "Last Week"
   > 
   > More unformatted text.
   > EOF
-  [ERROR(S)]: input stream
+  [ERROR(S)]: <stdin>
   
   Missing includes section: LAST WEEK
   [1]
@@ -46,7 +46,7 @@ The include_section checker looks for all passed sections
   > 
   > More unformatted text.
   > EOF
-  [ERROR(S)]: input stream
+  [ERROR(S)]: <stdin>
   
   Missing includes section: NEXT WEEK,
   LAST WEEK

--- a/test/cram/lint/short.t
+++ b/test/cram/lint/short.t
@@ -16,7 +16,7 @@ And with 1 when there is an error:
   > - Everything is great (E1)
   >   - Did everything
   > EOF
-  <stdin>:1:No time found in "Everything is great"
+  <stdin>:3:No time found in "Everything is great"
   [1]
 
 This also works with files:

--- a/test/cram/lint/short.t
+++ b/test/cram/lint/short.t
@@ -1,0 +1,41 @@
+Short mode exits with 0 when there is no error:
+
+  $ okra lint --short << EOF
+  > # Last week
+  > 
+  > - Everything is great (E1)
+  >   - @a (1 day)
+  >   - Did everything
+  > EOF
+
+And with 1 when there is an error:
+
+  $ okra lint --short << EOF
+  > # Last week
+  > 
+  > - Everything is great (E1)
+  >   - Did everything
+  > EOF
+  <stdin>:1:No time found in "Everything is great"
+  [1]
+
+This also works with files:
+
+  $ cat > a.md << EOF
+  > # Last week
+  > 
+  > - Everything is great (E1)
+  >   * @a (1 day)
+  >   * Did everything
+  > EOF
+
+  $ cat > b.md << EOF
+  > - Everything is great (E1)
+  >   - Did everything
+  > EOF
+
+  $ okra lint --short a.md b.md
+  a.md:4:* used as bullet point, this can confuse the parser. Only use - as bullet marker.
+  a.md:5:* used as bullet point, this can confuse the parser. Only use - as bullet marker.
+  b.md:1:No time found in "Everything is great"
+  [1]

--- a/test/cram/lint/team.t
+++ b/test/cram/lint/team.t
@@ -15,7 +15,7 @@ Examples of valid ones:
   >   - @eng1 (1 day)
   >   - My work
   > EOF
-  [OK]: input stream
+  [OK]: <stdin>
   $ okra lint --team << EOF
   > # This is a title
   > 
@@ -23,7 +23,7 @@ Examples of valid ones:
   >   - @eng1 (1 day)
   >   - My work
   > EOF
-  [OK]: input stream
+  [OK]: <stdin>
   $ okra lint --team << EOF
   > # This is a title
   > 
@@ -34,7 +34,7 @@ Examples of valid ones:
   >   - My work
   >   - More work
   > EOF
-  [OK]: input stream
+  [OK]: <stdin>
 
 Errors are not ignored outside the ignored section
 
@@ -50,7 +50,7 @@ Errors are not ignored outside the ignored section
   >   - @eng1 (1 day)
   >  - My work
   > EOF
-  [ERROR(S)]: input stream
+  [ERROR(S)]: <stdin>
   
   Line 10: Single space used for indentation (' - text'). Remove or replace by 2 or more spaces.
   1 formatting errors found. Parsing aborted.

--- a/test/cram/lint/time.t
+++ b/test/cram/lint/time.t
@@ -10,7 +10,7 @@ Invalid time
   >   - @eng1 (1 day), eng2 (2 days)
   >   - My work
   > EOF
-  [ERROR(S)]: input stream
+  [ERROR(S)]: <stdin>
   
   In KR "@eng1 (1 day), eng2 (2 days)":
     Invalid time entry found. Format is '- @eng1 (x days), @eng2 (x days)'
@@ -22,7 +22,7 @@ Invalid time
   >   - @eng1 (1 day); @eng2 (2 days)
   >   - My work
   > EOF
-  [ERROR(S)]: input stream
+  [ERROR(S)]: <stdin>
   
   In KR "@eng1 (1 day); @eng2 (2 days)":
     Invalid time entry found. Format is '- @eng1 (x days), @eng2 (x days)'
@@ -34,7 +34,7 @@ Invalid time
   >   - @eng1 (1 day) @eng2 (2 days)
   >   - My work
   > EOF
-  [ERROR(S)]: input stream
+  [ERROR(S)]: <stdin>
   
   In KR "@eng1 (1 day) @eng2 (2 days)":
     Invalid time entry found. Format is '- @eng1 (x days), @eng2 (x days)'
@@ -65,4 +65,4 @@ Valid time
   >   - @eng1 (0.1 days), @eng1 (.5 day)
   >   - My work
   > EOF
-  [OK]: input stream
+  [OK]: <stdin>


### PR DESCRIPTION
This adds a `--short` option to `lint`.

When active, it outputs to stdout and and emits one line per error, using the format `file:line:message`. This can be used for editor integration.
