### PR TITLE
add OK output to linting with some colours

### DIFF
--- a/test/bin/README.md
+++ b/test/bin/README.md
@@ -200,7 +200,7 @@ $ cat bactrian.bad.md
   - @bactrian (3 days)
   - wrote some html
 $ okra lint --engineer bactrian.bad.md
-Error(s) in file bactrian.bad.md:
+[ERROR(S)]: file bactrian.bad.md
 
 In KR "Make Okra, the OKR management tool":
   No time entry found. Each KR must be followed by '- @... (x days)'
@@ -225,6 +225,7 @@ $ cat bactrian.good.md
   - @bactrian (3 days)
   - wrote some html
 $ okra lint --engineer bactrian.good.md
+[OK]: file bactrian.good.md
 ```
 
 ## Team Leads

--- a/test/cram/lint/engineer.t
+++ b/test/cram/lint/engineer.t
@@ -21,6 +21,7 @@ This is a valid one:
   > 
   > More unformatted text.
   > EOF
+  [OK]: input stream
 
 Errors in include section are detected even if the rest is ignored.
 
@@ -42,7 +43,7 @@ Errors in include section are detected even if the rest is ignored.
   > 
   > More unformatted text.
   > EOF
-  Error(s) in input stream:
+  [ERROR(S)]: input stream
   
   In KR "This is a KR (KRID)":
     No time entry found. Each KR must be followed by '- @... (x days)'

--- a/test/cram/lint/errors.t
+++ b/test/cram/lint/errors.t
@@ -10,7 +10,7 @@ No KR ID found:
   >   - @eng1 (1 day)
   >   - My work
   > EOF
-  Error(s) in input stream:
+  [ERROR(S)]: input stream
   
   In KR "This is a KR":
     No KR ID found. KRs should be in the format "This is a KR (PLAT123)", where PLAT123 is the KR ID. For KRs that don't have an ID yet, use "New KR".
@@ -21,7 +21,7 @@ No KR ID found:
   >   - @eng1 (1 day)
   >   - My work
   > EOF
-  Error(s) in input stream:
+  [ERROR(S)]: input stream
   
   In KR "This is a KR":
     No project found (starting with '#')
@@ -35,7 +35,7 @@ No work items found:
   > - This is a KR (KRID)
   >   - @eng1 (1 day)
   > EOF
-  Error(s) in input stream:
+  [ERROR(S)]: input stream
   
   In KR "This is a KR (KRID)":
     No work items found. This may indicate an unreported parsing error. Remove the KR if it is without work.
@@ -50,7 +50,7 @@ No time entry found:
   >   - My work
   >   - @eng1 (1 day)
   > EOF
-  Error(s) in input stream:
+  [ERROR(S)]: input stream
   
   In KR "This is a KR":
     No time entry found. Each KR must be followed by '- @... (x days)'
@@ -67,7 +67,7 @@ Multiple time entries:
   >   - @eng2 (2 days)
   >   - More work
   > EOF
-  Error(s) in input stream:
+  [ERROR(S)]: input stream
   
   In KR "This is a KR":
     Multiple time entries found. Only one time entry should follow immediately after the KR.
@@ -82,7 +82,7 @@ Format errors
   >   - @eng1 (1 day)
   >   + My work
   > EOF
-  Error(s) in input stream:
+  [ERROR(S)]: input stream
   
   Line 5: + used as bullet point, this can confuse the parser. Only use - as bullet marker.
   1 formatting errors found. Parsing aborted.
@@ -94,7 +94,7 @@ Format errors
   >   - @eng1 (1 day)
   >   - My work
   > EOF
-  Error(s) in input stream:
+  [ERROR(S)]: input stream
   
   Line 1: Space found before title marker #. Start titles in first column.
   1 formatting errors found. Parsing aborted.
@@ -106,7 +106,7 @@ Format errors
   >   - @eng1 (1 day)
   >   - My work
   > EOF
-  Error(s) in input stream:
+  [ERROR(S)]: input stream
   
   Line 3: Single space used for indentation (' - text'). Remove or replace by 2 or more spaces.
   1 formatting errors found. Parsing aborted.

--- a/test/cram/lint/features.t
+++ b/test/cram/lint/features.t
@@ -7,7 +7,7 @@ Lint can read from a file:
   >   - Do it
   > EOF
   $ okra lint err.md
-  Error(s) in file err.md:
+  [ERROR(S)]: file err.md
   
   In KR "Everything is great":
     No time entry found. Each KR must be followed by '- @... (x days)'
@@ -16,7 +16,7 @@ Lint can read from a file:
 It can also read from stdin:
 
   $ okra lint < err.md
-  Error(s) in input stream:
+  [ERROR(S)]: input stream
   
   In KR "Everything is great":
     No time entry found. Each KR must be followed by '- @... (x days)'
@@ -33,7 +33,9 @@ If everything is fine, nothing is printed and it exits with 0:
   > EOF
 
   $ okra lint ok.md
+  [OK]: file ok.md
   $ okra lint < ok.md
+  [OK]: input stream
 
 When errors are found in several files, they are all printed:
 
@@ -45,11 +47,11 @@ When errors are found in several files, they are all printed:
   >   - Do it
   > EOF
   $ okra lint err.md err2.md
-  Error(s) in file err.md:
+  [ERROR(S)]: file err.md
   
   In KR "Everything is great":
     No time entry found. Each KR must be followed by '- @... (x days)'
-  Error(s) in file err2.md:
+  [ERROR(S)]: file err2.md
   
   In KR "@a":
     Invalid time entry found. Format is '- @eng1 (x days), @eng2 (x days)'

--- a/test/cram/lint/team.t
+++ b/test/cram/lint/team.t
@@ -15,6 +15,7 @@ Examples of valid ones:
   >   - @eng1 (1 day)
   >   - My work
   > EOF
+  [OK]: input stream
   $ okra lint --team << EOF
   > # This is a title
   > 
@@ -22,6 +23,7 @@ Examples of valid ones:
   >   - @eng1 (1 day)
   >   - My work
   > EOF
+  [OK]: input stream
   $ okra lint --team << EOF
   > # This is a title
   > 
@@ -32,6 +34,7 @@ Examples of valid ones:
   >   - My work
   >   - More work
   > EOF
+  [OK]: input stream
 
 Errors are not ignored outside the ignored section
 
@@ -47,7 +50,7 @@ Errors are not ignored outside the ignored section
   >   - @eng1 (1 day)
   >  - My work
   > EOF
-  Error(s) in input stream:
+  [ERROR(S)]: input stream
   
   Line 10: Single space used for indentation (' - text'). Remove or replace by 2 or more spaces.
   1 formatting errors found. Parsing aborted.

--- a/test/cram/lint/time.t
+++ b/test/cram/lint/time.t
@@ -10,7 +10,7 @@ Invalid time
   >   - @eng1 (1 day), eng2 (2 days)
   >   - My work
   > EOF
-  Error(s) in input stream:
+  [ERROR(S)]: input stream
   
   In KR "@eng1 (1 day), eng2 (2 days)":
     Invalid time entry found. Format is '- @eng1 (x days), @eng2 (x days)'
@@ -22,7 +22,7 @@ Invalid time
   >   - @eng1 (1 day); @eng2 (2 days)
   >   - My work
   > EOF
-  Error(s) in input stream:
+  [ERROR(S)]: input stream
   
   In KR "@eng1 (1 day); @eng2 (2 days)":
     Invalid time entry found. Format is '- @eng1 (x days), @eng2 (x days)'
@@ -34,7 +34,7 @@ Invalid time
   >   - @eng1 (1 day) @eng2 (2 days)
   >   - My work
   > EOF
-  Error(s) in input stream:
+  [ERROR(S)]: input stream
   
   In KR "@eng1 (1 day) @eng2 (2 days)":
     Invalid time entry found. Format is '- @eng1 (x days), @eng2 (x days)'
@@ -65,3 +65,4 @@ Valid time
   >   - @eng1 (0.1 days), @eng1 (.5 day)
   >   - My work
   > EOF
+  [OK]: input stream


### PR DESCRIPTION
Very simple change to print `[OK]: filename` when linting to reassure anyone piping multiple filenames into `okra lint` that we are in fact linting said files. A little bit of colour too.