### PR TITLE
add basic gitlab support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ setup.log
 
 # Local OPAM switch
 _opam/
+ocaml-gitlab

--- a/bin/conf.ml
+++ b/bin/conf.ml
@@ -22,6 +22,7 @@ type t = {
   locations : string list;
   footer : string option;
   okr_db : string option;
+  gitlab_token : string option;
 }
 
 let default =
@@ -30,6 +31,7 @@ let default =
     locations = [];
     footer = None;
     okr_db = None;
+    gitlab_token = None;
   }
 
 let conf_err s = Error (`Msg (Fmt.str "Okra Conf Error: %s" s))
@@ -79,12 +81,14 @@ let of_yaml yaml =
   find "locations" yaml >>= map_option to_string_exn >>= fun locations ->
   find "footer" yaml >>| Option.map to_string_exn >>= fun footer ->
   find "okr-db" yaml >>| Option.map to_string_exn >>= fun okr_db ->
-  Ok { projects; locations; footer; okr_db }
+  find "gitlab_token" yaml >>| Option.map to_string_exn >>= fun gitlab_token ->
+  Ok { projects; locations; footer; okr_db; gitlab_token }
 
 let projects { projects; _ } = projects
 let locations { locations; _ } = locations
 let footer { footer; _ } = footer
 let okr_db t = t.okr_db
+let gitlab_token t = t.gitlab_token
 
 let load file =
   let open Rresult in

--- a/bin/conf.mli
+++ b/bin/conf.mli
@@ -32,6 +32,10 @@ val footer : t -> string option
 val okr_db : t -> string option
 (** [okr_db] is the location of the OKR database. *)
 
+val gitlab_token : t -> string option
+(** [gitlab_token] is the optional Gitlab token, if present your Gitlab activity
+    will also be queried. *)
+
 val load : string -> (t, [ `Msg of string ]) result
 (** [load file] attempts to load a configuration from [file] *)
 

--- a/dune-project
+++ b/dune-project
@@ -34,6 +34,7 @@
   logs
   fmt
   get-activity
+  gitlab
   calendar
   csv
   (omd (>= 2.0))))

--- a/okra.opam
+++ b/okra.opam
@@ -34,5 +34,4 @@ build: [
 ]
 pin-depends: [
   ["get-activity.dev" "git+https://github.com/patricoferris/get-activity#e63fe7b6e56aabbcd2693e7d1bf64a793fd18593"]
-  ["gitlab.dev" "git+https://github.com/tmcgilchrist/ocaml-gitlab#3e0e9b731fe6f68989643dccb378e57c02cfc834"]
 ]

--- a/okra.opam
+++ b/okra.opam
@@ -12,6 +12,7 @@ depends: [
   "logs"
   "fmt"
   "get-activity"
+  "gitlab"
   "calendar"
   "csv"
   "omd" {>= "2.0"}

--- a/okra.opam
+++ b/okra.opam
@@ -33,4 +33,5 @@ build: [
 ]
 pin-depends: [
   ["get-activity.dev" "git+https://github.com/patricoferris/get-activity#e63fe7b6e56aabbcd2693e7d1bf64a793fd18593"]
+  ["gitlab.dev" "git+https://github.com/patricoferris/ocaml-gitlab#42897350c0ed6ef3caf65d09405edbfba846bd2e"]
 ]

--- a/okra.opam
+++ b/okra.opam
@@ -34,5 +34,5 @@ build: [
 ]
 pin-depends: [
   ["get-activity.dev" "git+https://github.com/patricoferris/get-activity#e63fe7b6e56aabbcd2693e7d1bf64a793fd18593"]
-  ["gitlab.dev" "git+https://github.com/patricoferris/ocaml-gitlab#42897350c0ed6ef3caf65d09405edbfba846bd2e"]
+  ["gitlab.dev" "git+https://github.com/patricoferris/ocaml-gitlab#6bea7eecfd3ddc37759dc7f7cba6ad93d6593263"]
 ]

--- a/okra.opam
+++ b/okra.opam
@@ -34,5 +34,5 @@ build: [
 ]
 pin-depends: [
   ["get-activity.dev" "git+https://github.com/patricoferris/get-activity#e63fe7b6e56aabbcd2693e7d1bf64a793fd18593"]
-  ["gitlab.dev" "git+https://github.com/tmcgilchrist/ocaml-gitlab#f198dcd854e21f36d12a1a54c512d87f4f7996eb"]
+  ["gitlab.dev" "git+https://github.com/tmcgilchrist/ocaml-gitlab#3e0e9b731fe6f68989643dccb378e57c02cfc834"]
 ]

--- a/okra.opam
+++ b/okra.opam
@@ -34,5 +34,5 @@ build: [
 ]
 pin-depends: [
   ["get-activity.dev" "git+https://github.com/patricoferris/get-activity#e63fe7b6e56aabbcd2693e7d1bf64a793fd18593"]
-  ["gitlab.dev" "git+https://github.com/patricoferris/ocaml-gitlab#6bea7eecfd3ddc37759dc7f7cba6ad93d6593263"]
+  ["gitlab.dev" "git+https://github.com/tmcgilchrist/ocaml-gitlab#f198dcd854e21f36d12a1a54c512d87f4f7996eb"]
 ]

--- a/okra.opam.template
+++ b/okra.opam.template
@@ -1,4 +1,4 @@
 pin-depends: [
   ["get-activity.dev" "git+https://github.com/patricoferris/get-activity#e63fe7b6e56aabbcd2693e7d1bf64a793fd18593"]
-  ["gitlab.dev" "git+https://github.com/patricoferris/ocaml-gitlab#6bea7eecfd3ddc37759dc7f7cba6ad93d6593263"]
+  ["gitlab.dev" "git+https://github.com/tmcgilchrist/ocaml-gitlab#f198dcd854e21f36d12a1a54c512d87f4f7996eb"]
 ]

--- a/okra.opam.template
+++ b/okra.opam.template
@@ -1,4 +1,4 @@
 pin-depends: [
   ["get-activity.dev" "git+https://github.com/patricoferris/get-activity#e63fe7b6e56aabbcd2693e7d1bf64a793fd18593"]
-  ["gitlab.dev" "git+https://github.com/patricoferris/ocaml-gitlab#42897350c0ed6ef3caf65d09405edbfba846bd2e"]
+  ["gitlab.dev" "git+https://github.com/patricoferris/ocaml-gitlab#6bea7eecfd3ddc37759dc7f7cba6ad93d6593263"]
 ]

--- a/okra.opam.template
+++ b/okra.opam.template
@@ -1,3 +1,4 @@
 pin-depends: [
   ["get-activity.dev" "git+https://github.com/patricoferris/get-activity#e63fe7b6e56aabbcd2693e7d1bf64a793fd18593"]
+  ["gitlab.dev" "git+https://github.com/patricoferris/ocaml-gitlab#42897350c0ed6ef3caf65d09405edbfba846bd2e"]
 ]

--- a/okra.opam.template
+++ b/okra.opam.template
@@ -1,4 +1,4 @@
 pin-depends: [
   ["get-activity.dev" "git+https://github.com/patricoferris/get-activity#e63fe7b6e56aabbcd2693e7d1bf64a793fd18593"]
-  ["gitlab.dev" "git+https://github.com/tmcgilchrist/ocaml-gitlab#f198dcd854e21f36d12a1a54c512d87f4f7996eb"]
+  ["gitlab.dev" "git+https://github.com/tmcgilchrist/ocaml-gitlab#3e0e9b731fe6f68989643dccb378e57c02cfc834"]
 ]

--- a/okra.opam.template
+++ b/okra.opam.template
@@ -1,4 +1,3 @@
 pin-depends: [
   ["get-activity.dev" "git+https://github.com/patricoferris/get-activity#e63fe7b6e56aabbcd2693e7d1bf64a793fd18593"]
-  ["gitlab.dev" "git+https://github.com/tmcgilchrist/ocaml-gitlab#3e0e9b731fe6f68989643dccb378e57c02cfc834"]
 ]

--- a/src/activity.ml
+++ b/src/activity.ml
@@ -47,21 +47,34 @@ let repo_org ?(with_id = false) ?(no_links = false) f s =
   | repo :: org :: _ -> Fmt.pf f "[%s/%s](%s)" org repo s
   | _ -> Fmt.failwith "Malformed URL %S" s
 
-let pp_ga_item ~no_links f (t : Get_activity.Contributions.item) =
-  match t.kind with
-  | `Issue ->
-      Fmt.pf f "Issue: %s %a" t.title (repo_org ~with_id:true ~no_links) t.url
-  | `PR -> Fmt.pf f "PR: %s %a" t.title (repo_org ~with_id:true ~no_links) t.url
-  | `Review s ->
-      Fmt.pf f "%s %s %a" s t.title (repo_org ~with_id:true ~no_links) t.url
-  | `New_repo ->
-      Fmt.pf f "Created repository %a"
-        (repo_org ~with_id:false ~no_links:false)
-        t.url
+let pp_ga_item ?(gitlab = false) ~no_links () f
+    (t : Get_activity.Contributions.item) =
+  match gitlab with
+  | true -> (
+      match t.kind with
+      | `PR -> Fmt.pf f "PR (Gitlab): %s %s" t.title t.url
+      | `Issue -> Fmt.pf f "Issue (Gitlab): %s %s" t.title t.url
+      | _ -> ())
+  | false -> (
+      match t.kind with
+      | `Issue ->
+          Fmt.pf f "Issue: %s %a" t.title
+            (repo_org ~with_id:true ~no_links)
+            t.url
+      | `PR ->
+          Fmt.pf f "PR: %s %a" t.title (repo_org ~with_id:true ~no_links) t.url
+      | `Review s ->
+          Fmt.pf f "%s %s %a" s t.title (repo_org ~with_id:true ~no_links) t.url
+      | `New_repo ->
+          Fmt.pf f "Created repository %a"
+            (repo_org ~with_id:false ~no_links)
+            t.url)
 
-let pp_activity ~no_links ppf activity =
+let pp_activity ?(gitlab = false) ~no_links () ppf activity =
   let open Get_activity.Contributions in
-  let pp_item ppf item = Fmt.pf ppf "  - %a" (pp_ga_item ~no_links) item in
+  let pp_item ppf item =
+    Fmt.pf ppf "  - %a" (pp_ga_item ~gitlab ~no_links ()) item
+  in
   let bindings = Repo_map.bindings activity in
   let pp_binding ppf (_repo, items) =
     Fmt.pf ppf "%a" Fmt.(list pp_item) items
@@ -70,7 +83,8 @@ let pp_activity ~no_links ppf activity =
 
 let make ~projects activity = { projects; activity }
 
-let pp ?(no_links = false) ppf { projects; activity = { username; activity } } =
+let pp ?(gitlab = false) ?(no_links = false) () ppf
+    { projects; activity = { username; activity } } =
   Fmt.pf ppf
     {|# Projects
 
@@ -85,4 +99,110 @@ let pp ?(no_links = false) ppf { projects; activity = { username; activity } } =
 |}
     Fmt.(list (fun ppf s -> Fmt.pf ppf "- %s" s))
     (List.map title projects) (pp_last_week username) projects
-    (pp_activity ~no_links) activity
+    (pp_activity ~gitlab ~no_links ())
+    activity
+
+(* The equivalent get-activity style information for Gitlab
+   is in the Events API *)
+module Gitlab = struct
+  open Get_activity.Contributions
+
+  let make_pull_request url (v : Gitlab_t.event) =
+    {
+      repo = string_of_int v.event_project_id;
+      kind = `PR;
+      date = v.event_created_at;
+      url;
+      title =
+        Fmt.str "%a %s"
+          Fmt.(option string)
+          (Option.map Gitlab_j.string_of_event_action_name v.event_action_name)
+          (Option.value ~default:"Gitlab PR" v.event_target_title);
+      body = Option.value ~default:"Gitlab PR" v.event_target_title;
+    }
+
+  let make_issue url (v : Gitlab_t.event) =
+    {
+      repo = string_of_int v.event_project_id;
+      kind = `Issue;
+      date = v.event_created_at;
+      url;
+      title = Option.value ~default:"Gitlab Issue" v.event_target_title;
+      body = Option.value ~default:"Gitlab Issue" v.event_target_title;
+    }
+
+  let to_repo_map :
+      Gitlab_t.events * (int * Gitlab_t.project_short) list ->
+      item list Repo_map.t =
+   fun (evs, projects) ->
+    let to_ga_item (ev : Gitlab_t.event) =
+      let project = List.assoc_opt ev.event_project_id projects in
+      match (project, ev.event_target_type) with
+      | Some project, Some `MergeRequest ->
+          let url =
+            Fmt.str "%s/-/merge_requests/%a" project.project_short_web_url
+              Fmt.(option int)
+              ev.event_target_iid
+          in
+          Some (make_pull_request url ev)
+      | Some project, Some `Issue ->
+          let url =
+            Fmt.str "%s/-/issues/%a" project.project_short_web_url
+              Fmt.(option int)
+              ev.event_target_iid
+          in
+          Some (make_issue url ev)
+      | _ -> None
+    in
+    let lst = List.filter_map to_ga_item evs in
+    let repo = Repo_map.empty in
+    List.fold_left
+      (fun map item ->
+        match Repo_map.find_opt "Gitlab" map with
+        | Some items -> Repo_map.add "Gitlab" (item :: items) map
+        | None -> Repo_map.add "Gitlab" [ item ] map)
+      repo lst
+
+  module Fetch
+      (Env : Gitlab_s.Env)
+      (Time : Gitlab_s.Time)
+      (CL : Cohttp_lwt.S.Client) =
+  struct
+    module G = Gitlab_core.Make (Env) (Time) (CL)
+    open G.Monad
+
+    let map_s f l =
+      let open G.Monad in
+      let rec inner acc = function
+        | [] -> List.rev acc |> return
+        | hd :: tl -> f hd >>= fun r -> inner (r :: acc) tl
+      in
+      inner [] l
+
+    let get_project ~token i =
+      let uri = Uri.of_string (Fmt.str "%s/projects/%i" Env.gitlab_uri i) in
+      let+ res =
+        G.API.get ~token ~uri (fun body ->
+            Lwt.return @@ Gitlab_j.project_short_of_string body)
+      in
+      (i, G.Response.value res)
+
+    let make_activity ~token ~before ~after =
+      let open G.Monad in
+      let uri = Uri.of_string (Fmt.str "%s/events" Env.gitlab_uri) in
+      let uri =
+        Uri.add_query_params uri
+          [ ("before", [ before ]); ("after", [ after ]) ]
+      in
+      let* res =
+        G.API.get ~token ~uri (fun body ->
+            Lwt.return (Gitlab_j.events_of_string body))
+      in
+      let events = G.Response.value res in
+      let ids =
+        List.map (fun (v : Gitlab_t.event) -> v.event_project_id) events
+        |> List.sort_uniq Int.compare
+      in
+      map_s (get_project ~token) ids >>= fun ids -> return (events, ids)
+  end
+end

--- a/src/calendar.ml
+++ b/src/calendar.ml
@@ -68,3 +68,11 @@ let to_iso8601 t =
   (* We store the dates, not the times as well so we add the extra day minus one second *)
   ( Cal.Date.to_unixfloat t.from |> Get_activity.Period.to_8601,
     Cal.Date.to_unixfloat t.to_ +. day -. 1. |> Get_activity.Period.to_8601 )
+
+let format_gitlab f = CalendarLib.Printer.Date.fprint "%0Y-%0m-%0d" f
+
+let to_gitlab t =
+  let from, to_ = range t in
+  (* Seems the Gitlab API is not inclusive of the lower bound day ? *)
+  let day_before = Cal.Date.(prev from `Day) in
+  (Fmt.str "%a" format_gitlab day_before, Fmt.str "%a" format_gitlab to_)

--- a/src/calendar.mli
+++ b/src/calendar.mli
@@ -47,3 +47,6 @@ val range : t -> date * date
 
 val to_iso8601 : t -> string * string
 (** [to_iso8601 t] converts [t] to the ISO8601 format *)
+
+val to_gitlab : t -> string * string
+(** [to_gitlab t] converts [t] to Gitlab API format (e.g. 2021-12-29) *)

--- a/src/dune
+++ b/src/dune
@@ -1,4 +1,4 @@
 (library
  (name okra)
  (public_name okra)
- (libraries logs omd fmt str calendar csv get-activity))
+ (libraries logs omd fmt str calendar csv get-activity gitlab))

--- a/test/expect/test_engineer.ml
+++ b/test/expect/test_engineer.ml
@@ -74,4 +74,4 @@ let activity =
   let activities = { username = "bactrian"; activity } in
   Activity.make ~projects activities
 
-let () = Activity.pp Fmt.stdout activity
+let () = Activity.pp () Fmt.stdout activity


### PR DESCRIPTION
This PR adds basic Gitlab support (it's a draft as I need to upstream some changes to `ocaml-gitlab`). It only integrates Merge Requests and Issues at the moment. I have a feeling it might be a little verbose and add an activity for every event like commenting on an issue, so I will test that too. For now it is enough to have an okra conf like:

```yaml
gitlab_token: <READ-USER-TOKEN>
```

And `okra generate` will add activities like:

```markdown
  - PR (Gitlab): "opened" update readme https://gitlab.com/patrickferris/ocaml-sctp/-/merge_requests/1
  - PR (Gitlab): "accepted" update readme https://gitlab.com/patrickferris/ocaml-sctp/-/merge_requests/1
  - Issue (Gitlab): The protocol needs to be implemented https://gitlab.com/patrickferris/ocaml-sctp/-/issues/1
```

Not sure what the best formatting is so happy to hear suggestions on that too.