### PR TITLE
add with-repositories to okra generate

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,19 +209,19 @@ There are multiple ways to specify the time-frame you are interested in with the
  - You can specify a range of weeks using the `weeks` argument, so `okra generate --weeks=33-39` will get all of your activity from the start of week 33 to the **end** of week 39.
  - Finally, you can also specify `--month=X` to generate a report from the first to the last day of a particular month (with January being `1`). 
 
-There is also a `--with-repositories` argument where you can specify a comma-separated list of Github repositories. Each repository will have all of its PRs filtered to find the ones you merged. Most people probably don't need to use this feature, it's only useful for people who spend time on other people's PRs and don't explicitly approve the PR using the Github web UI.
+There is also a `--include-repositories` argument where you can specify a comma-separated list of Github repositories. Each repository will have all of its PRs filtered to find the ones you merged. Most people probably don't need to use this feature, it's only useful for people who spend time on other people's PRs and don't explicitly approve the PR using the Github web UI.
 
 These all apply to generating a repository report too which is next.
 
 ### Repository Report
 
-A repository report gets the PRs and issues that were "active" for a given time period for a particular set of repositories. This uses the same `generate` command as the engineer report, but if you supply `--repositories=X` this will produce a repository report. `X` should be a comma-separated list of `owner/repo` Github repositories, for example:
+A repository report gets the PRs and issues that were "active" for a given time period for a particular set of repositories. This uses the same `generate` command as the engineer report, but if you supply `--kind=repository` this will produce a repository report. The positional arguments are then interpreted as `owner/repo` Github repositories, for example:
 
 ```
-okra generate --repositories=mirage/irmin,mirage/mirage --month=9
+okra generate --kind=repository --month=10 mirage/irmin mirage/mirage
 ```
 
-This will generate a single report with an Irmin and Mirage section for September (and the current year). Note, the Github API isn't as useful for repositories so the further back in time you go, the more requests have to be made to the API and the long the report will take to produce.
+This will generate a single report with an Irmin and Mirage section for October (and the current year). Note, the Github API isn't as useful for repositories so the further back in time you go, the more requests have to be made to the API and the long the report will take to produce.
 
 ### Team activity report
 

--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ There are multiple ways to specify the time-frame you are interested in with the
  - You can specify a range of weeks using the `weeks` argument, so `okra generate --weeks=33-39` will get all of your activity from the start of week 33 to the **end** of week 39.
  - Finally, you can also specify `--month=X` to generate a report from the first to the last day of a particular month (with January being `1`). 
 
+There is also a `--with-repositories` argument where you can specify a comma-separated list of Github repositories. Each repository will have all of its PRs filtered to find the ones you merged. Most people probably don't need to use this feature, it's only useful for people who spend time on other people's PRs and don't explicitly approve the PR using the Github web UI.
+
 These all apply to generating a repository report too which is next.
 
 ### Repository Report

--- a/src/activity.mli
+++ b/src/activity.mli
@@ -23,6 +23,9 @@ type project = { title : string; items : string list }
 val make : projects:project list -> Get_activity.Contributions.t -> t
 (** [make_activity ~projects activites] builds a new weekly activity *)
 
+val pp_ga_item : no_links:bool -> Get_activity.Contributions.item Fmt.t
+(** [pp_ga_item ppf item] prints the get-activity item *)
+
 val pp : ?no_links:bool -> t Fmt.t
 (** [pp ppf activity] formats a weekly activity into a template that needs some
     editing to get it into the correct format.

--- a/src/repo_report.ml
+++ b/src/repo_report.ml
@@ -23,7 +23,12 @@ module U = Yojson.Safe.Util
 
 let ( / ) a b = U.member b a
 let ( // ) a b = try Some (U.member b a) with _ -> None
-let underscore s = String.split_on_char '-' s |> String.concat "_"
+
+let underscore s =
+  String.split_on_char '-' s
+  |> String.concat "_"
+  |> String.split_on_char '.'
+  |> String.concat "_"
 
 module Issue = struct
   type t = {
@@ -86,6 +91,7 @@ module PR = struct
     created_at : string;
     is_draft : bool;
     merged_at : string option;
+    merged_by : string option;
     reviewers : string list;
   }
 
@@ -101,6 +107,7 @@ module PR = struct
     let closed_at = json / "closedAt" |> U.to_string_option in
     let is_draft = json / "isDraft" |> U.to_bool in
     let merged_at = json / "mergedAt" |> U.to_string_option in
+    let merged_by = Option.map U.to_string @@ (json / "mergedBy" // "login") in
     let reviewers =
       json / "reviews" / "nodes"
       |> U.to_list
@@ -118,6 +125,7 @@ module PR = struct
       created_at;
       is_draft;
       merged_at;
+      merged_by;
       reviewers;
     }
 
@@ -167,6 +175,9 @@ module PR = struct
         isDraft
         merged
         mergedAt
+        mergedBy {
+          login
+        }
         reviews (last: 100) {
           nodes {
             author {

--- a/src/repo_report.mli
+++ b/src/repo_report.mli
@@ -45,6 +45,7 @@ module PR : sig
     created_at : string;
     is_draft : bool;
     merged_at : string option;
+    merged_by : string option;
     reviewers : string list;
   }
 

--- a/test/expect/test_monthly.ml
+++ b/test/expect/test_monthly.ml
@@ -55,6 +55,7 @@ let repo_report =
                 created_at = "2021-02-01T00:00:00Z";
                 is_draft = false;
                 merged_at = None;
+                merged_by = None;
                 reviewers = [ "Dromedary" ];
               };
               {
@@ -68,6 +69,7 @@ let repo_report =
                 created_at = "2021-02-01T00:00:01Z";
                 is_draft = false;
                 merged_at = Some "2021-02-01T00:00:02Z";
+                merged_by = Some "Dromedary";
                 reviewers = [ "Dromedary" ];
               };
             ];


### PR DESCRIPTION
This PR re-uses the `okra generate` features for repository reports in the engineer reports if a comma-separated list of repos is given using `--with-repositories` for example:

```
okra generate --with-repositories=ocaml/opam-repository
```

This will do the normal engineer report and then append to the activity all of the PRs that the user _merged_ in that period for the specified repositories. I'm not quite sure it will capture all of them (depending on how you look at it) given we only include PRs _created_ in the period specified (not _merged_ in that period). If everything happens within the period (e.g. a week) it'll be captured.

This (I hope) is a useful first-step for #50