### PR TITLE
add --append-to for cat

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ $ cat magnus.md patrick.md | okra cat --engineer
     - Fixing mdx
 ```
 
+It may be the case that you have an existing report (`agg.md`) and a new report comes in that you wish to merge into this report. You can do this with the `--append-to` flag for example `okra cat --engineer patrick.md --append-to=agg.md`.
+
 If `--team` is specified, everything except what is listed under `OKR Updates` is included. This is useful for aggregating reports from multiple teams (or over multiple weeks).
 
 ```

--- a/bin/cat.ml
+++ b/bin/cat.ml
@@ -125,9 +125,7 @@ let run conf =
     | Some file ->
         let content = read_file file in
         let exisiting =
-          (* Assumes the conf flags will work for the aggregate report *)
-          Okra.Report.of_markdown ~ignore_sections:conf.ignore_sections
-            ~include_sections:conf.include_sections (Omd.of_string content)
+          Okra.Report.of_markdown ?okr_db (Omd.of_string content)
         in
         Some exisiting
   in

--- a/src/report.ml
+++ b/src/report.ml
@@ -237,8 +237,11 @@ let of_objectives ~project objectives =
   let p : project = { name = project; objectives } in
   of_projects [ p ]
 
-let of_markdown ?ignore_sections ?include_sections ?okr_db m =
-  of_krs ?okr_db (Parser.of_markdown ?ignore_sections ?include_sections m)
+let of_markdown ?existing_report ?ignore_sections ?include_sections ?okr_db m =
+  let new_krs = Parser.of_markdown ?ignore_sections ?include_sections m in
+  let old_krs = match existing_report with None -> [] | Some t -> all_krs t in
+  let krs = old_krs @ new_krs in
+  of_krs ?okr_db krs
 
 let make_objective ?show_time ?show_time_calc ?show_engineers o =
   let krs = Hashtbl.to_seq o.krs.ids |> Seq.map snd |> List.of_seq in

--- a/src/report.mli
+++ b/src/report.mli
@@ -46,6 +46,7 @@ val of_projects : project list -> t
 val of_objectives : project:string -> objective list -> t
 
 val of_markdown :
+  ?existing_report:t ->
   ?ignore_sections:string list ->
   ?include_sections:string list ->
   ?okr_db:Masterdb.t ->

--- a/test/cram/cat/aggr.t
+++ b/test/cram/cat/aggr.t
@@ -57,3 +57,23 @@ Engineer reports are aggregated correctly
     - @eng1 (0.5 days), @eng2 (1 day)
     - Little bit of work
     - Small bit of work
+
+  $ okra cat --engineer eng1.md > agg.md && okra cat -e eng2.md --append-to agg.md
+  # Last Week
+  
+  - A Kr (KR123)
+    - @eng1 (1.5 days), @eng2 (1.5 days)
+    - Some work
+    - Some work
+  
+  - A new KR (New KR)
+    - @eng1 (1 day)
+    - Some work
+  
+  - A new KR, but different title (New KR)
+    - @eng2 (1 day)
+    - Some work
+  
+  - Work without a KR (No KR)
+    - @eng2 (1 day)
+    - Small bit of work

--- a/test/cram/cat/aggr.t
+++ b/test/cram/cat/aggr.t
@@ -37,6 +37,15 @@ Engineer reports are aggregated correctly
   > 
   > EOF
 
+  $ cat > okrs.csv << EOF
+  > id,title,objective,status,schedule,lead,team,category,project
+  > KR1,Actual title,Actual objective,active,,,,,Actual project
+  > Kr2,Actual title 2,Actual objective,active,,,,,Actual project
+  > KR3,Dropped KR,Actual objective,dropped,,,,,Actual project
+  > KR4,Unscheduled KR,Actual objective,unscheduled,,,,,Actual project
+  > KR123,Missing status KR,Actual objective,,,,,,Actual project
+  > EOF
+
   $ cat eng1.md eng2.md | okra cat --engineer
   # Last Week
   
@@ -56,24 +65,4 @@ Engineer reports are aggregated correctly
   - Work without a KR (No KR)
     - @eng1 (0.5 days), @eng2 (1 day)
     - Little bit of work
-    - Small bit of work
-
-  $ okra cat --engineer eng1.md > agg.md && okra cat -e eng2.md --append-to agg.md
-  # Last Week
-  
-  - A Kr (KR123)
-    - @eng1 (1.5 days), @eng2 (1.5 days)
-    - Some work
-    - Some work
-  
-  - A new KR (New KR)
-    - @eng1 (1 day)
-    - Some work
-  
-  - A new KR, but different title (New KR)
-    - @eng2 (1 day)
-    - Some work
-  
-  - Work without a KR (No KR)
-    - @eng2 (1 day)
     - Small bit of work

--- a/test/cram/cat/merge.t
+++ b/test/cram/cat/merge.t
@@ -1,0 +1,115 @@
+Appending
+---------
+
+Engineer reports are aggregated correctly
+
+  $ cat > eng1.md << EOF
+  > # Last Week
+  > 
+  > - A Kr (KR123)
+  >   - @eng1 (1.5 days)
+  >   - Some work
+  > 
+  > EOF
+
+  $ cat > eng2.md << EOF
+  > # Last Week
+  > 
+  > - A Kr (KR123)
+  >   - @eng2 (1.5 days)
+  >   - Some other work
+  > 
+  > EOF
+
+  $ cat > eng3.md << EOF
+  > # Last Week
+  > 
+  > - A Kr (KR123)
+  >   - @eng3 (1.5 days)
+  >   - Some other, other work
+  > 
+  > - A Different Kr (KR124)
+  >   - @eng3 (1.5 days)
+  >   - Some work
+  > 
+  > EOF
+
+  $ cat > okrs.csv << EOF
+  > id,title,objective,status,schedule,lead,team,category,project
+  > KR123,A Kr,Actual objective,active,,,,,Actual project
+  > KR124,A Different Kr,Actual objective,active,,,,,Actual project
+  > EOF
+
+Behaviour without a database
+
+  $ cat eng1.md eng2.md | okra cat --engineer > agg.md && cat agg.md
+  # Last Week
+  
+  - A Kr (KR123)
+    - @eng1 (1.5 days), @eng2 (1.5 days)
+    - Some work
+    - Some other work
+
+  $ okra cat --engineer --append-to=agg.md eng3.md > agg2.md && cat agg2.md
+  # Last Week
+  
+  - A Kr (KR123)
+    - @eng1 (1.5 days), @eng2 (1.5 days), @eng3 (1.5 days)
+    - Some work
+    - Some other work
+    - Some other, other work
+  
+  - A Different Kr (KR124)
+    - @eng3 (1.5 days)
+    - Some work
+
+Behaviour with a database
+
+  $ cat eng1.md eng2.md | okra cat --okr-db=okrs.csv --engineer > agg.md && cat agg.md
+  okra: [WARNING] Objective for KR "KR123" does not match objective in database:
+  - ""
+  - "Actual objective"
+  okra: [WARNING] Project for KR "KR123" does not match project in database:
+  - "Last Week"
+  - "Actual project"
+  okra: [WARNING] Objective for KR "KR123" does not match objective in database:
+  - ""
+  - "Actual objective"
+  okra: [WARNING] Project for KR "KR123" does not match project in database:
+  - "Last Week"
+  - "Actual project"
+  # Actual project
+  
+  ## Actual objective
+  
+  - A Kr (KR123)
+    - @eng1 (1.5 days), @eng2 (1.5 days)
+    - Some work
+    - Some other work
+
+  $ okra cat --okr-db=okrs.csv --engineer --append-to=agg.md eng3.md > agg2.md && cat agg2.md
+  okra: [WARNING] Objective for KR "KR123" does not match objective in database:
+  - ""
+  - "Actual objective"
+  okra: [WARNING] Project for KR "KR123" does not match project in database:
+  - "Last Week"
+  - "Actual project"
+  okra: [WARNING] Objective for KR "KR124" does not match objective in database:
+  - ""
+  - "Actual objective"
+  okra: [WARNING] Project for KR "KR124" does not match project in database:
+  - "Last Week"
+  - "Actual project"
+  # Actual project
+  
+  ## Actual objective
+  
+  - A Kr (KR123)
+    - @eng1 (1.5 days), @eng2 (1.5 days), @eng3 (1.5 days)
+    - Some work
+    - Some other work
+    - Some other, other work
+  
+  - A Different Kr (KR124)
+    - @eng3 (1.5 days)
+    - Some work


### PR DESCRIPTION
Fixes #87. This PR adds the `--append-to` argument to take some existing report and merge new reports into it (note I've only tested it on `--engineer`).

EDIT: I think the `team` bit is more important actually re-reading the issue, will fix tomorrow. 