### PR TITLE
Make report printing more configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,8 @@ okra generate --kind=repository --month=10 mirage/irmin mirage/mirage
 
 This will generate a single report with an Irmin and Mirage section for October (and the current year). Note, the Github API isn't as useful for repositories so the further back in time you go, the more requests have to be made to the API and the long the report will take to produce.
 
+By default the repository report does not contain author names, time of creation/merge or the description of the issue/PR. There are flags called `--with-names`, `--with-times` and `--with-descriptions` to toggle these respectively.
+
 ### Team activity report
 
 The expected team report format is similar, but here every section is parsed and multiple engineers may have worked on each KR. Any section called `OKR Updates` is ignored by default and may be used to propose KR changes.

--- a/src/repo_report.mli
+++ b/src/repo_report.mli
@@ -29,7 +29,8 @@ module Issue : sig
   val parse : Yojson.Safe.t -> t
   (** Parses the json received from the Github Graphql API *)
 
-  val pp : t Fmt.t
+  val pp :
+    with_names:bool -> with_times:bool -> with_descriptions:bool -> t Fmt.t
   (** Prints the issue to a markdown format *)
 end
 
@@ -55,7 +56,8 @@ module PR : sig
   val parse : Yojson.Safe.t -> t
   (** Parses the json received from the Github Graphql API *)
 
-  val pp : t Fmt.t
+  val pp :
+    with_names:bool -> with_times:bool -> with_descriptions:bool -> t Fmt.t
   (** Prints the issue to a markdown format *)
 
   val query : string
@@ -63,6 +65,7 @@ module PR : sig
 end
 
 type data = {
+  org : string;
   repo : string;
   description : string option;
   issues : Issue.t list;
@@ -85,5 +88,6 @@ module Make (C : Cohttp_lwt.S.Client) : sig
       specified [period] using the Github [token] *)
 end
 
-val pp : t Fmt.t
+val pp :
+  ?with_names:bool -> ?with_times:bool -> ?with_descriptions:bool -> t Fmt.t
 (** Prints a markdown formatted view of the data *)

--- a/test/expect/test_monthly.expected
+++ b/test/expect/test_monthly.expected
@@ -1,24 +1,25 @@
-# mirage/irmin
+## [irmin](https://github.com/mirage/irmin)
 Irmin is a distributed database that follows the same design principles as Git
 
-## Pull Requests
+### Pull Requests
 
-### Opened (and not merged in same time frame)
+#### Opened (and not merged in same time frame)
 
  - [Small fix](https://github.com/mirage/irmin) by @Bactrian
 
    (created: 2021-02-01T00:00:00Z, reviewed by: @Dromedary)
+   Fixes a small thing
 
 
-### Merged
+#### Merged
 
  - [Smaller fix](https://github.com/mirage/irmin) by @Bactrian
 
    (merged: 2021-02-01T00:00:02Z, reviewed by: @Dromedary)
+   Fixes a really small thing
 
 
-## Issues
+### Issues
 
-- [Small bug](https://github.com/mirage/irmin) by @Dromedary
-
-   (created: 2021-01-27T00:00:00Z)
+ - [Small bug](https://github.com/mirage/irmin) by @Dromedary (created/merged: 2021-01-27T00:00:00Z)
+   A small bug

--- a/test/expect/test_monthly.ml
+++ b/test/expect/test_monthly.ml
@@ -22,7 +22,8 @@ let repo_report =
   let data : data =
     Repo_report.
       {
-        repo = "mirage/irmin";
+        org = "mirage";
+        repo = "irmin";
         description =
           Some
             "Irmin is a distributed database that follows the same design \
@@ -77,4 +78,6 @@ let repo_report =
   in
   Project_map.add "mirage/irmin" data map
 
-let () = Repo_report.pp Fmt.stdout repo_report
+let () =
+  Repo_report.pp ~with_names:true ~with_times:true ~with_descriptions:true
+    Fmt.stdout repo_report


### PR DESCRIPTION
This PR adds three options for printing repository reports:
 - `with-names` includes the author of the PR/Issue
 - `with-times` includes the created/merged at datetime
 - `with-descriptions` includes the body of the PR/Issue

By default these are not set making the report more readable. 