### PR TITLE
generate: add a way to fetch data for another user

### DIFF
--- a/okra.opam
+++ b/okra.opam
@@ -33,5 +33,5 @@ build: [
   ]
 ]
 pin-depends: [
-  ["get-activity.dev" "git+https://github.com/patricoferris/get-activity#e63fe7b6e56aabbcd2693e7d1bf64a793fd18593"]
+  ["get-activity.dev" "git+https://github.com/emillon/get-activity#a2dc8f80fa353811e3be237ff8968c6f38b4c637"]
 ]

--- a/okra.opam.template
+++ b/okra.opam.template
@@ -1,3 +1,3 @@
 pin-depends: [
-  ["get-activity.dev" "git+https://github.com/patricoferris/get-activity#e63fe7b6e56aabbcd2693e7d1bf64a793fd18593"]
+  ["get-activity.dev" "git+https://github.com/emillon/get-activity#a2dc8f80fa353811e3be237ff8968c6f38b4c637"]
 ]


### PR DESCRIPTION
When `--user` is passed, contributions are fetched from this user, not the one that corresponds to the github token.
