### PR TITLE
Remove noisy warnings

### DIFF
--- a/src/KR.ml
+++ b/src/KR.ml
@@ -201,26 +201,6 @@ let update_from_master_db t db =
     match db_kr with
     | None -> orig_kr
     | Some db_kr ->
-        if orig_kr.id = No_KR || orig_kr.id = New_KR then
-          Log.warn (fun l ->
-              l "KR ID updated from unspecified to %S :\n- %S\n- %S" db_kr.id
-                orig_kr.title db_kr.title);
-        if orig_kr.title <> db_kr.title then
-          Log.warn (fun l ->
-              l "Title for KR %S does not match title in database:\n- %S\n- %S"
-                db_kr.id orig_kr.title db_kr.title);
-        if orig_kr.objective <> db_kr.objective then
-          Log.warn (fun l ->
-              l
-                "Objective for KR %S does not match objective in database:\n\
-                 - %S\n\
-                 - %S" db_kr.id orig_kr.objective db_kr.objective);
-        if orig_kr.project <> db_kr.project then
-          Log.warn (fun l ->
-              l
-                "Project for KR %S does not match project in database:\n\
-                 - %S\n\
-                 - %S" db_kr.id orig_kr.project db_kr.project);
         (match db_kr.status with
         | Some Active | Some Scheduled -> ()
         | Some s ->

--- a/src/KR.ml
+++ b/src/KR.ml
@@ -199,8 +199,15 @@ let make_time_entries t =
 let update_from_master_db t db =
   let update (orig_kr : t) (db_kr : Masterdb.elt_t option) =
     match db_kr with
-    | None -> orig_kr
+    | None ->
+        if orig_kr.id = New_KR then
+          Log.warn (fun l -> l "KR ID not found for new KR %S" orig_kr.title);
+        orig_kr
     | Some db_kr ->
+        if orig_kr.id = No_KR then
+          Log.warn (fun l ->
+              l "KR ID updated from \"No KR\" to %S:\n- %S\n- %S" db_kr.id
+                orig_kr.title db_kr.title);
         (match db_kr.status with
         | Some Active -> ()
         | Some s ->

--- a/src/KR.ml
+++ b/src/KR.ml
@@ -202,7 +202,7 @@ let update_from_master_db t db =
     | None -> orig_kr
     | Some db_kr ->
         (match db_kr.status with
-        | Some Active | Some Scheduled -> ()
+        | Some Active -> ()
         | Some s ->
             Log.warn (fun l ->
                 l "Work logged on KR marked as %S: %S (%S)"

--- a/test/cram/cat/masterdb.t
+++ b/test/cram/cat/masterdb.t
@@ -21,15 +21,6 @@ When `--okr-db` is passed, metadata is fixed.
   >   - @a (1 day)
   >   - Did all the things
   > EOF
-  okra: [WARNING] Title for KR "KR1" does not match title in database:
-  - "Wrong title"
-  - "Actual title"
-  okra: [WARNING] Objective for KR "KR1" does not match objective in database:
-  - "Wrong objective"
-  - "Actual objective"
-  okra: [WARNING] Project for KR "KR1" does not match project in database:
-  - "Wrong project"
-  - "Actual project"
   # Actual project
   
   ## Actual objective
@@ -58,6 +49,7 @@ In that case, metadata is preserved.
   >   - @a (1 day)
   >   - Did all the things
   > EOF
+  okra: [WARNING] KR ID not found for new KR "Something else"
   # Actual project
   
   ## Actual objective
@@ -86,9 +78,6 @@ If KR ID is "New KR", look for title in database to get real KR ID.
   >   - Did all the things
   > 
   > EOF
-  okra: [WARNING] KR ID updated from unspecified to "KR1" :
-  - "Actual title"
-  - "Actual title"
   # Actual project
   
   ## Actual objective
@@ -109,7 +98,7 @@ If KR ID is "No KR", look for title in database to get real KR ID.
   >   - Did all the things
   > 
   > EOF
-  okra: [WARNING] KR ID updated from unspecified to "KR1" :
+  okra: [WARNING] KR ID updated from "No KR" to "KR1":
   - "Actual title"
   - "Actual title"
   # Actual project

--- a/test/cram/cat/merge.t
+++ b/test/cram/cat/merge.t
@@ -66,18 +66,6 @@ Behaviour without a database
 Behaviour with a database
 
   $ cat eng1.md eng2.md | okra cat --okr-db=okrs.csv --engineer > agg.md && cat agg.md
-  okra: [WARNING] Objective for KR "KR123" does not match objective in database:
-  - ""
-  - "Actual objective"
-  okra: [WARNING] Project for KR "KR123" does not match project in database:
-  - "Last Week"
-  - "Actual project"
-  okra: [WARNING] Objective for KR "KR123" does not match objective in database:
-  - ""
-  - "Actual objective"
-  okra: [WARNING] Project for KR "KR123" does not match project in database:
-  - "Last Week"
-  - "Actual project"
   # Actual project
   
   ## Actual objective
@@ -88,18 +76,6 @@ Behaviour with a database
     - Some other work
 
   $ okra cat --okr-db=okrs.csv --engineer --append-to=agg.md eng3.md > agg2.md && cat agg2.md
-  okra: [WARNING] Objective for KR "KR123" does not match objective in database:
-  - ""
-  - "Actual objective"
-  okra: [WARNING] Project for KR "KR123" does not match project in database:
-  - "Last Week"
-  - "Actual project"
-  okra: [WARNING] Objective for KR "KR124" does not match objective in database:
-  - ""
-  - "Actual objective"
-  okra: [WARNING] Project for KR "KR124" does not match project in database:
-  - "Last Week"
-  - "Actual project"
   # Actual project
   
   ## Actual objective


### PR DESCRIPTION
When using a database:
- Remove warnings for changing project, title and objective
- Add warning for "New KR"s that are not replaced with the correct ID
- Add warning for "No KR"s that are replaced (this may be unexpected)
- Add warning when logging work on Scheduled KRs (they should be active if work is logged)