### PR TITLE
Pin to gitlab 0.1.0 for now, also add missing fields

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -8,6 +8,8 @@
 (license ISC)
 (authors "Magnus Skjegstad")
 (maintainers "magnus@skjegstad.com")
+(homepage "https://github.com/magnuss/okra")
+(bug_reports "https://github.com/MagnusS/okra/issues")
 
 (package
  (name okra-bin)
@@ -34,7 +36,7 @@
   logs
   fmt
   get-activity
-  gitlab
+  (gitlab (= 0.1.0))
   calendar
   csv
   (omd (>= 2.0))))

--- a/okra-bin.opam
+++ b/okra-bin.opam
@@ -5,6 +5,8 @@ description: "An executable to be used for report parsing"
 maintainer: ["magnus@skjegstad.com"]
 authors: ["Magnus Skjegstad"]
 license: "ISC"
+homepage: "https://github.com/magnuss/okra"
+bug-reports: "https://github.com/MagnusS/okra/issues"
 depends: [
   "dune" {>= "2.8"}
   "alcotest" {with-test}

--- a/okra.opam
+++ b/okra.opam
@@ -5,6 +5,8 @@ description: "A library of tools for report parsing"
 maintainer: ["magnus@skjegstad.com"]
 authors: ["Magnus Skjegstad"]
 license: "ISC"
+homepage: "https://github.com/magnuss/okra"
+bug-reports: "https://github.com/MagnusS/okra/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.10"}
@@ -12,7 +14,7 @@ depends: [
   "logs"
   "fmt"
   "get-activity"
-  "gitlab"
+  "gitlab" {= "0.1.0"}
   "calendar"
   "csv"
   "omd" {>= "2.0"}


### PR DESCRIPTION
gitlab 0.1.1 uses int64 so breaks the build , pin to old version temporarily