### PR TITLE
Add more filtering options to cat (teams, reports, categories)

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,5 +1,6 @@
-version = 0.19.0
+version = 0.21.0
 profile = conventional
 break-infix = fit-or-vertical
 parse-docstrings = true
 module-item-spacing = compact
+ocaml-version = 4.08.0

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,10 @@
+## Changes (unreleased)
+
+- Use ocamlformat 0.21.0
+- CSV parsing updates. Include new fields for reports and links. (@magnuss)
+- Add support for filtering data on team, category and report-type (@magnuss)
+- Update cmdliner (#103, @tmcgilchrist)
+- Update gitlab (#100, @tmcgilchrist)
+- Add --version option (#99, @magnuss)
+
+(changes before Jan '22 not tracked)

--- a/bin/cat.ml
+++ b/bin/cat.ml
@@ -177,7 +177,7 @@ let conf_term =
   and+ show_time_calc = show_time_calc_term
   and+ show_engineers = show_engineers_term
   and+ okr_db = okr_db_term
-  and+ append_to
+  and+ append_to = append_to
   and+ filter = Common.filter
   and+ ignore_sections = Common.ignore_sections
   and+ include_sections = Common.include_sections

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -17,6 +17,33 @@
 
 open Cmdliner
 
+let include_categories =
+  let i =
+    Arg.info [ "include-categories" ]
+      ~doc:
+        "If non-empty, only aggregate KRs in these categories. Requires a \
+         database."
+  in
+  Arg.(value & opt (list string) [] i)
+
+let include_teams =
+  let i =
+    Arg.info [ "include-teams" ]
+      ~doc:
+        "If non-empty, only aggregate KRs from these teams. Requires a \
+         database."
+  in
+  Arg.(value & opt (list string) [] i)
+
+let include_reports =
+  let i =
+    Arg.info [ "include-reports" ]
+      ~doc:
+        "If non-empty, only aggregate KRs that are included in one of these reports. Requires a \
+         database."
+  in
+  Arg.(value & opt (list string) [] i)
+
 let include_sections =
   let i =
     Arg.info [ "include-sections" ]

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -39,8 +39,8 @@ let include_reports =
   let i =
     Arg.info [ "include-reports" ]
       ~doc:
-        "If non-empty, only aggregate KRs that are included in one of these reports. Requires a \
-         database."
+        "If non-empty, only aggregate KRs that are included in one of these \
+         reports. Requires a database."
   in
   Arg.(value & opt (list string) [] i)
 

--- a/bin/common.mli
+++ b/bin/common.mli
@@ -19,6 +19,9 @@ open Cmdliner
 
 val include_sections : string list Term.t
 val ignore_sections : string list Term.t
+val include_categories : string list Term.t
+val include_teams : string list Term.t
+val include_reports : string list Term.t
 val filter : Okra.Report.filter Term.t
 val files : string list Term.t
 val output : string option Term.t

--- a/dune-project
+++ b/dune-project
@@ -37,7 +37,7 @@
   logs
   fmt
   get-activity
-  (gitlab (>= 0.1.2))
+  (gitlab (= 0.1.2))
   calendar
   csv
   (omd (>= 2.0))))

--- a/okra.opam
+++ b/okra.opam
@@ -14,7 +14,7 @@ depends: [
   "logs"
   "fmt"
   "get-activity"
-  "gitlab" {>= "0.1.2"}
+  "gitlab" {= "0.1.2"}
   "calendar"
   "csv"
   "omd" {>= "2.0"}

--- a/src/calendar.ml
+++ b/src/calendar.ml
@@ -20,7 +20,6 @@ type date = Cal.Date.t
 type t = { from : date; to_ : date }
 
 let week t = Cal.Date.week t.from (* ISO compliant? *)
-
 let month t = Cal.Date.month t.from |> Cal.Date.int_of_month
 let year t = Cal.Date.year t.from
 let day = 60. *. 60. *. 24.

--- a/src/masterdb.ml
+++ b/src/masterdb.ml
@@ -80,13 +80,13 @@ let load_csv ?(separator = ',') f =
         line := !line + 1;
         let find_and_trim col = Csv.Row.find row col |> String.trim in
         let find_and_trim_opt col =
-                let v = find_and_trim col in
-                if v <> "" then Some v else None
+          let v = find_and_trim col in
+          if v <> "" then Some v else None
         in
         let find_and_trim_list col =
-                match find_and_trim_opt col with
-                | None -> []
-                | Some s -> Str.split (Str.regexp "[ ,]+") s
+          match find_and_trim_opt col with
+          | None -> []
+          | Some s -> Str.split (Str.regexp "[ ,]+") s
         in
         let printable_id = find_and_trim "id" in
         let e =
@@ -146,29 +146,28 @@ let find_title_opt t title =
     okrs
 
 let filter_krs t f =
-        let v = Hashtbl.to_seq_values t in
-        List.of_seq (Seq.filter f v)
+  let v = Hashtbl.to_seq_values t in
+  List.of_seq (Seq.filter f v)
 
 let find_krs_for_teams t teams =
-        let teams = List.map String.uppercase_ascii teams in
-        let p e =
-                List.exists (String.equal (String.uppercase_ascii e.team)) teams
-        in
-        filter_krs t p
+  let teams = List.map String.uppercase_ascii teams in
+  let p e = List.exists (String.equal (String.uppercase_ascii e.team)) teams in
+  filter_krs t p
 
 let find_krs_for_categories t categories =
-        let categories = List.map String.uppercase_ascii categories in
-        let p e =
-                List.exists (String.equal (String.uppercase_ascii e.category)) categories
-        in
-        filter_krs t p
+  let categories = List.map String.uppercase_ascii categories in
+  let p e =
+    List.exists (String.equal (String.uppercase_ascii e.category)) categories
+  in
+  filter_krs t p
 
 let find_krs_for_reports t reports =
-        let reports = List.map String.uppercase_ascii reports in
-        let p e =
-                List.exists (fun report ->
-                                let report = String.uppercase_ascii report in
-                                List.exists (String.equal report) reports)
-                e.reports
-        in
-        filter_krs t p
+  let reports = List.map String.uppercase_ascii reports in
+  let p e =
+    List.exists
+      (fun report ->
+        let report = String.uppercase_ascii report in
+        List.exists (String.equal report) reports)
+      e.reports
+  in
+  filter_krs t p

--- a/src/masterdb.ml
+++ b/src/masterdb.ml
@@ -37,10 +37,12 @@ type elt_t = {
   title : string;
   objective : string;
   project : string;
-  schedule : string;
+  schedule : string option;
   lead : string;
   team : string;
   category : string;
+  links : string option;
+  reports : string list;
   status : status_t option;
 }
 
@@ -77,6 +79,15 @@ let load_csv ?(separator = ',') f =
       ~f:(fun row ->
         line := !line + 1;
         let find_and_trim col = Csv.Row.find row col |> String.trim in
+        let find_and_trim_opt col =
+                let v = find_and_trim col in
+                if v <> "" then Some v else None
+        in
+        let find_and_trim_list col =
+                match find_and_trim_opt col with
+                | None -> []
+                | Some s -> Str.split (Str.regexp "[ ,]+") s
+        in
         let printable_id = find_and_trim "id" in
         let e =
           {
@@ -85,10 +96,12 @@ let load_csv ?(separator = ',') f =
             title = find_and_trim "title";
             objective = find_and_trim "objective";
             project = find_and_trim "project";
-            schedule = find_and_trim "schedule";
+            schedule = find_and_trim_opt "schedule";
             lead = find_and_trim "lead";
             team = find_and_trim "team";
             category = find_and_trim "category";
+            reports = find_and_trim_list "reports";
+            links = find_and_trim_opt "links";
             status = find_and_trim "status" |> status_of_string;
           }
         in
@@ -131,3 +144,31 @@ let find_title_opt t title =
     (fun kr ->
       kr.title |> String.uppercase_ascii |> String.trim = title_no_case)
     okrs
+
+let filter_krs t f =
+        let v = Hashtbl.to_seq_values t in
+        List.of_seq (Seq.filter f v)
+
+let find_krs_for_teams t teams =
+        let teams = List.map String.uppercase_ascii teams in
+        let p e =
+                List.exists (String.equal (String.uppercase_ascii e.team)) teams
+        in
+        filter_krs t p
+
+let find_krs_for_categories t categories =
+        let categories = List.map String.uppercase_ascii categories in
+        let p e =
+                List.exists (String.equal (String.uppercase_ascii e.category)) categories
+        in
+        filter_krs t p
+
+let find_krs_for_reports t reports =
+        let reports = List.map String.uppercase_ascii reports in
+        let p e =
+                List.exists (fun report ->
+                                let report = String.uppercase_ascii report in
+                                List.exists (String.equal report) reports)
+                e.reports
+        in
+        filter_krs t p

--- a/src/masterdb.mli
+++ b/src/masterdb.mli
@@ -37,10 +37,12 @@ type elt_t = private {
   title : string;
   objective : string;
   project : string;
-  schedule : string;
+  schedule : string option;
   lead : string;
   team : string;
   category : string;
+  links : string option;
+  reports : string list;
   status : status_t option;
 }
 
@@ -51,4 +53,7 @@ val load_csv : ?separator:char -> string -> t
 val find_kr_opt : t -> string -> elt_t option
 val find_kr : t -> string -> elt_t
 val find_title_opt : t -> string -> elt_t option
+val find_krs_for_teams : t -> string list -> elt_t list
+val find_krs_for_reports : t -> string list -> elt_t list
+val find_krs_for_categories : t -> string list -> elt_t list
 val has_kr : t -> string -> bool

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -22,17 +22,11 @@ module Log = (val Logs.src_log src : Logs.LOG)
 open Omd
 
 exception No_time_found of string (* Record found without a time record *)
-
 exception Invalid_time of string (* Time record found, but has errors *)
-
 exception No_work_found of string (* No work items found under KR *)
-
 exception Multiple_time_entries of string (* More than one time entry found *)
-
 exception No_KR_ID_found of string (* Empty or no KR ID *)
-
 exception No_project_found of string (* No project found *)
-
 exception Invalid_markdown_in_work_items of string
 (* Subset of markdown not supported in work items *)
 

--- a/src/report.ml
+++ b/src/report.ml
@@ -338,16 +338,20 @@ module Filter = struct
     && StringSet.is_empty f.exclude_engineers
 
   let union t1 t2 =
-          {
-                  include_projects = StringSet.union t1.include_projects t2.include_projects;
-                  exclude_projects = StringSet.union t1.exclude_projects t2.exclude_projects;
-                  include_objectives = StringSet.union t1.include_objectives t2.include_objectives;
-                  exclude_objectives = StringSet.union t1.exclude_objectives t2.exclude_objectives;
-                  include_krs = StringSet.union t1.include_krs t2.include_krs;
-                  exclude_krs = StringSet.union t1.exclude_krs t2.exclude_krs;
-                  include_engineers = StringSet.union t1.include_engineers t2.include_engineers;
-                  exclude_engineers = StringSet.union t1.exclude_engineers t2.exclude_engineers;
-          }
+    {
+      include_projects = StringSet.union t1.include_projects t2.include_projects;
+      exclude_projects = StringSet.union t1.exclude_projects t2.exclude_projects;
+      include_objectives =
+        StringSet.union t1.include_objectives t2.include_objectives;
+      exclude_objectives =
+        StringSet.union t1.exclude_objectives t2.exclude_objectives;
+      include_krs = StringSet.union t1.include_krs t2.include_krs;
+      exclude_krs = StringSet.union t1.exclude_krs t2.exclude_krs;
+      include_engineers =
+        StringSet.union t1.include_engineers t2.include_engineers;
+      exclude_engineers =
+        StringSet.union t1.exclude_engineers t2.exclude_engineers;
+    }
 
   let v ?(include_projects = []) ?(exclude_projects = [])
       ?(include_objectives = []) ?(exclude_objectives = []) ?(include_krs = [])

--- a/src/report.ml
+++ b/src/report.ml
@@ -337,6 +337,18 @@ module Filter = struct
     && StringSet.is_empty f.include_engineers
     && StringSet.is_empty f.exclude_engineers
 
+  let union t1 t2 =
+          {
+                  include_projects = StringSet.union t1.include_projects t2.include_projects;
+                  exclude_projects = StringSet.union t1.exclude_projects t2.exclude_projects;
+                  include_objectives = StringSet.union t1.include_objectives t2.include_objectives;
+                  exclude_objectives = StringSet.union t1.exclude_objectives t2.exclude_objectives;
+                  include_krs = StringSet.union t1.include_krs t2.include_krs;
+                  exclude_krs = StringSet.union t1.exclude_krs t2.exclude_krs;
+                  include_engineers = StringSet.union t1.include_engineers t2.include_engineers;
+                  exclude_engineers = StringSet.union t1.exclude_engineers t2.exclude_engineers;
+          }
+
   let v ?(include_projects = []) ?(exclude_projects = [])
       ?(include_objectives = []) ?(exclude_objectives = []) ?(include_krs = [])
       ?(exclude_krs = []) ?(include_engineers = []) ?(exclude_engineers = []) ()

--- a/src/report.mli
+++ b/src/report.mli
@@ -94,6 +94,9 @@ module Filter : sig
 
   val string_of_kr : KR.id -> string
 
+  val union : t -> t -> t
+  (** Combine two filters into a new filter *)
+
   val v :
     ?include_projects:string list ->
     ?exclude_projects:string list ->

--- a/test/cram/cat/masterdb.t
+++ b/test/cram/cat/masterdb.t
@@ -4,12 +4,12 @@ Master DB
 When `--okr-db` is passed, metadata is fixed.
 
   $ cat > okrs.csv << EOF
-  > id,title,objective,status,schedule,lead,team,category,project
-  > KR1,Actual title,Actual objective,active,,,,,Actual project
-  > Kr2,Actual title 2,Actual objective,active,,,,,Actual project
-  > KR3,Dropped KR,Actual objective,dropped,,,,,Actual project
-  > KR4,Unscheduled KR,Actual objective,unscheduled,,,,,Actual project
-  > KR5,Missing status KR,Actual objective,,,,,,Actual project
+  > id,title,objective,status,links,schedule,lead,team,category,project,reports
+  > KR1,Actual title,Actual objective,active,,,,team1,category1,Actual project,"report1,report2"
+  > Kr2,Actual title 2,Actual objective,active,,,,team1,category2,Actual project,report2
+  > KR3,Dropped KR,Actual objective,dropped,,,,team2,category1,Actual project,report1
+  > KR4,Unscheduled KR,Actual objective,unscheduled,,,,team2,category2,Actual project,report1
+  > KR5,Missing status KR,Actual objective,,,,,team2,category1,Actual project,report1
   > EOF
 
   $ okra cat --okr-db=okrs.csv << EOF
@@ -28,6 +28,100 @@ When `--okr-db` is passed, metadata is fixed.
   - Actual title (KR1)
     - @a (1 day)
     - Did all the things
+
+It is possible to filter on category.
+
+  $ okra cat --okr-db=okrs.csv --include-categories=category2 << EOF
+  > # Actual project
+  > 
+  > ## Actual objective
+  > 
+  > - Actual title (kr1)
+  >   - @a (1 day)
+  >   - Did all the things
+  > 
+  > - Actual title 2 (KR2)
+  >   - @b (1 day)
+  >   - Did more of the things
+  > 
+  > EOF
+  # Actual project
+  
+  ## Actual objective
+  
+  - Actual title 2 (Kr2)
+    - @b (1 day)
+    - Did more of the things
+
+It is possible to filter by report.
+
+  $ okra cat --okr-db=okrs.csv --include-reports=report2 << EOF
+  > # Project
+  > 
+  > - Actual title (KR1)
+  >   - @a (1 day)
+  >   - Did all the things
+  > 
+  > - Dropped KR (KR3)
+  >   - @a (1 day)
+  >   - Did more of the things
+  > EOF
+  okra: [WARNING] Work logged on KR marked as "Dropped": "Dropped KR" ("KR3")
+  # Actual project
+  
+  ## Actual objective
+  
+  - Actual title (KR1)
+    - @a (1 day)
+    - Did all the things
+
+It is possible to filter by team.
+
+  $ okra cat --okr-db=okrs.csv --include-teams=team1 << EOF
+  > # Project
+  > 
+  > - Actual title (KR1)
+  >   - @a (1 day)
+  >   - Did all the things
+  > 
+  > - Dropped KR (KR3)
+  >   - @a (1 day)
+  >   - Did more of the things
+  > EOF
+  okra: [WARNING] Work logged on KR marked as "Dropped": "Dropped KR" ("KR3")
+  # Actual project
+  
+  ## Actual objective
+  
+  - Actual title (KR1)
+    - @a (1 day)
+    - Did all the things
+
+It is possible to filter on more than one team.
+
+  $ okra cat --okr-db=okrs.csv --include-teams=team1,team2 << EOF
+  > # Project
+  > 
+  > - Actual title (KR1)
+  >   - @a (1 day)
+  >   - Did all the things
+  > 
+  > - Dropped KR (KR3)
+  >   - @a (1 day)
+  >   - Did more of the things
+  > EOF
+  okra: [WARNING] Work logged on KR marked as "Dropped": "Dropped KR" ("KR3")
+  # Actual project
+  
+  ## Actual objective
+  
+  - Actual title (KR1)
+    - @a (1 day)
+    - Did all the things
+  
+  - Dropped KR (KR3)
+    - @a (1 day)
+    - Did more of the things
 
 Instead of a KR ID, it is possible to put "New KR".
 In that case, metadata is preserved.

--- a/test/test_filter.ml
+++ b/test/test_filter.ml
@@ -142,7 +142,9 @@ let test_exclude_engineers () =
   let t2 = filter t ~include_krs:[ ID id3 ] ~include_engineers:[ e2 ] in
   let kr = get_kr t2 in
   Alcotest.(check (list (list (pair string (float 0.)))))
-    "check time entries" [ [ (e2, 10.) ] ] kr.KR.time_entries
+    "check time entries"
+    [ [ (e2, 10.) ] ]
+    kr.KR.time_entries
 
 let tests =
   [


### PR DESCRIPTION
Adds new options to `cat`:

`--include-categories=`
`--include-reports=`
`--include-teams=`

Metadata from the CSV will be used to extract a list of KRs that will be included in the `--include-krs` filter. Requires `--okr-db` to be set.

Bonus:
- Add more fields from the csv to masterdb
- Update to ocamlformat 0.21.0
- Add CHANGELOG