### PR TITLE
Somewhat hackily support gitlab-unix 0.1.3

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -37,8 +37,9 @@
   logs
   fmt
   get-activity
-  (gitlab (= 0.1.2))
+  (gitlab (>= 0.1.3))
   calendar
   csv
+  ISO8601
   (omd (>= 2.0))))
 (using mdx 0.1)

--- a/dune-project
+++ b/dune-project
@@ -37,9 +37,8 @@
   logs
   fmt
   get-activity
-  (gitlab (>= 0.1.3))
+  (gitlab (>= 0.1.4))
   calendar
   csv
-  ISO8601
   (omd (>= 2.0))))
 (using mdx 0.1)

--- a/okra.opam
+++ b/okra.opam
@@ -14,10 +14,9 @@ depends: [
   "logs"
   "fmt"
   "get-activity"
-  "gitlab" {>= "0.1.3"}
+  "gitlab" {>= "0.1.4"}
   "calendar"
   "csv"
-  "ISO8601"
   "omd" {>= "2.0"}
   "odoc" {with-doc}
 ]

--- a/okra.opam
+++ b/okra.opam
@@ -14,9 +14,10 @@ depends: [
   "logs"
   "fmt"
   "get-activity"
-  "gitlab" {= "0.1.2"}
+  "gitlab" {>= "0.1.3"}
   "calendar"
   "csv"
+  "ISO8601"
   "omd" {>= "2.0"}
   "odoc" {with-doc}
 ]

--- a/src/activity.ml
+++ b/src/activity.ml
@@ -111,7 +111,7 @@ module Gitlab = struct
     {
       repo = string_of_int v.event_project_id;
       kind = `PR;
-      date = v.event_created_at;
+      date = ISO8601.Permissive.string_of_datetime v.event_created_at;
       url;
       title =
         Fmt.str "%a %s"
@@ -125,7 +125,7 @@ module Gitlab = struct
     {
       repo = string_of_int v.event_project_id;
       kind = `Issue;
-      date = v.event_created_at;
+      date = ISO8601.Permissive.string_of_datetime v.event_created_at;
       url;
       title = Option.value ~default:"Gitlab Issue" v.event_target_title;
       body = Option.value ~default:"Gitlab Issue" v.event_target_title;

--- a/src/activity.ml
+++ b/src/activity.ml
@@ -111,7 +111,7 @@ module Gitlab = struct
     {
       repo = string_of_int v.event_project_id;
       kind = `PR;
-      date = ISO8601.Permissive.string_of_datetime v.event_created_at;
+      date = Gitlab_json.DateTime.unwrap v.event_created_at;
       url;
       title =
         Fmt.str "%a %s"
@@ -125,7 +125,7 @@ module Gitlab = struct
     {
       repo = string_of_int v.event_project_id;
       kind = `Issue;
-      date = ISO8601.Permissive.string_of_datetime v.event_created_at;
+      date = Gitlab_json.DateTime.unwrap v.event_created_at;
       url;
       title = Option.value ~default:"Gitlab Issue" v.event_target_title;
       body = Option.value ~default:"Gitlab Issue" v.event_target_title;

--- a/src/dune
+++ b/src/dune
@@ -1,4 +1,4 @@
 (library
  (name okra)
  (public_name okra)
- (libraries logs omd fmt str calendar csv get-activity gitlab ISO8601))
+ (libraries logs omd fmt str calendar csv get-activity gitlab))

--- a/src/dune
+++ b/src/dune
@@ -1,4 +1,4 @@
 (library
  (name okra)
  (public_name okra)
- (libraries logs omd fmt str calendar csv get-activity gitlab))
+ (libraries logs omd fmt str calendar csv get-activity gitlab ISO8601))


### PR DESCRIPTION
Hackily, since gitlab-unix has gone from ISO8601 to float and we then reverse that for compatibility with get-activity...