### PR TITLE
Add an `okra team lint` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ A list of projects you are working on can be provided in the configuration file 
 
 ```
 projects:
-  - "Improve OKRA (OKRA1)"
+  - title: "Improve OKRA (OKRA1)"
 ```
 
 More information is provided at the bottom of the README.
@@ -260,7 +260,7 @@ You can store a `conf.yaml` file in `~/.okra` to provide the binary with extra i
 ```yaml
 # Projects are used in weekly report generation (optional)
 projects:
-  - "Make okra great (Plat123)"
+  - title: "Make okra great (Plat123)"
 # Locations will be used in aggregation across multiple directories (optional)
 locations:
   - "/path/to/admin/dir1"

--- a/README.md
+++ b/README.md
@@ -173,7 +173,17 @@ or
 $ okra lint --team report.md
 ```
 
+You can also lint multiple engineer reports in one go with the `okra team lint` command.
 
+For instance, running:
+
+```
+$ okra team lint -C admin/ -W 40.41
+```
+
+Will lint the reports of all of the team members you defined in your configuration file.
+
+Note that you need to define one or multiple teams in your Okra configuration file for the `okra team` subcommands to function.
 
 ## Report formats
 
@@ -265,6 +275,14 @@ projects:
 locations:
   - "/path/to/admin/dir1"
   - "/path/to/admin/dir2"
+# Teams are used for the `okra team` subcommands.
+teams:
+  - name: My Team
+    members:
+      - name: Engineer 1
+        github: eng1
+      - name: Engineer 2
+        github: eng2
 footer: |
   # Meetings
   - A recurring meeting

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -169,9 +169,14 @@ let get_or_error = function
       exit 1
 
 let conf =
+  let conf_arg =
+    Arg.value
+    @@ Arg.opt Arg.file Conf.default_file_path
+    @@ Arg.info ~doc:"Okra configuration file" ~docv:"CONF" [ "conf" ]
+  in
   let load okra_file =
     match get_or_error @@ Bos.OS.File.exists (Fpath.v okra_file) with
     | false -> Conf.default
     | true -> get_or_error @@ Conf.load okra_file
   in
-  Term.(const load $ Conf.cmdliner)
+  Term.(const load $ conf_arg)

--- a/bin/conf.ml
+++ b/bin/conf.ml
@@ -13,7 +13,17 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
+
 open Okra
+
+let xdg =
+  Xdg.create
+    ~env:(fun x -> try Some (Unix.getenv x) with Not_found -> None)
+    ()
+
+let config_dir =
+  let ( / ) = Filename.concat in
+  Xdg.config_dir xdg / "okra"
 
 let default_project = { Activity.title = "TODO ADD KR (ID)"; items = [] }
 
@@ -95,11 +105,6 @@ let load file =
   Bos.OS.File.read (Fpath.v file) >>= fun contents ->
   Yaml.of_string contents >>= fun yaml -> of_yaml yaml
 
-let home =
-  match Sys.getenv_opt "HOME" with
-  | None -> Fmt.failwith "$HOME is not set!"
-  | Some dir -> dir
-
 let default_file_path =
   let ( / ) = Filename.concat in
-  home / ".okra" / "conf.yaml"
+  config_dir / "conf.yaml"

--- a/bin/conf.ml
+++ b/bin/conf.ml
@@ -27,9 +27,15 @@ let config_dir =
 
 let default_project = { Activity.title = "TODO ADD KR (ID)"; items = [] }
 
+type project = Activity.project = {
+  title : string;
+  items : string list; [@default []]
+}
+[@@deriving yaml]
 type t = {
-  projects : Activity.project list;
+  projects : project list; [@default [ default_project ]]
   locations : string list;
+  locations : string list; [@default []]
   footer : string option;
   okr_db : string option;
   gitlab_token : string option;
@@ -43,56 +49,6 @@ let default =
     okr_db = None;
     gitlab_token = None;
   }
-
-let conf_err s = Error (`Msg (Fmt.str "Okra Conf Error: %s" s))
-
-let projects_of_yaml t =
-  let open Rresult in
-  let open Yaml.Util in
-  let map (f : Yaml.value -> 'a) = function
-    | `A lst -> List.map f lst
-    | _ -> raise (Yaml.Util.Value_error "Expected a list to map over")
-  in
-  let project_of_yaml = function
-    | `String title -> { default_project with title }
-    | `O assoc -> (
-        let title = List.assoc_opt "title" assoc |> Option.map to_string_exn in
-        let items =
-          List.assoc_opt "items" assoc |> Option.map (map to_string_exn)
-        in
-        match (title, items) with
-        | Some title, Some items -> { title; items }
-        | Some title, None -> { default_project with title }
-        | _, _ ->
-            raise
-              (Value_error "expected a list of projects with at least a title"))
-    | _ ->
-        raise
-          (Value_error
-             "project description must be a list of strings or { title; items }")
-  in
-  match t with
-  | None -> Ok [ default_project ]
-  | Some (`A v) -> (
-      try Ok (List.map project_of_yaml v)
-      with Yaml.Util.Value_error s -> conf_err s)
-  | Some _ -> conf_err "Expected a list"
-
-let of_yaml yaml =
-  let open Rresult in
-  let open Yaml.Util in
-  let map_option f = function
-    | None -> Ok [ "TODO ADD KR (ID)" ]
-    | Some (`A v) -> (
-        try Ok (List.map f v) with Yaml.Util.Value_error s -> conf_err s)
-    | Some _ -> conf_err "Expected a list"
-  in
-  find "projects" yaml >>= projects_of_yaml >>= fun projects ->
-  find "locations" yaml >>= map_option to_string_exn >>= fun locations ->
-  find "footer" yaml >>| Option.map to_string_exn >>= fun footer ->
-  find "okr-db" yaml >>| Option.map to_string_exn >>= fun okr_db ->
-  find "gitlab_token" yaml >>| Option.map to_string_exn >>= fun gitlab_token ->
-  Ok { projects; locations; footer; okr_db; gitlab_token }
 
 let projects { projects; _ } = projects
 let locations { locations; _ } = locations

--- a/bin/conf.ml
+++ b/bin/conf.ml
@@ -100,13 +100,6 @@ let home =
   | None -> Fmt.failwith "$HOME is not set!"
   | Some dir -> dir
 
-let default_okra_file =
+let default_file_path =
   let ( / ) = Filename.concat in
   home / ".okra" / "conf.yaml"
-
-open Cmdliner
-
-let cmdliner =
-  Arg.value
-  @@ Arg.opt Arg.file default_okra_file
-  @@ Arg.info ~doc:"Okra configuration file" ~docv:"CONF" [ "conf" ]

--- a/bin/conf.ml
+++ b/bin/conf.ml
@@ -47,6 +47,7 @@ type t = {
   locations : string list; [@default []]
   footer : string option;
   okr_db : string option;
+  admin_dir : string option;
   gitlab_token : string option;
 }
 [@@deriving yaml]
@@ -58,6 +59,7 @@ let default =
     locations = [];
     footer = None;
     okr_db = None;
+    admin_dir = None;
     gitlab_token = None;
   }
 
@@ -77,6 +79,7 @@ let projects { projects; _ } = projects
 let locations { locations; _ } = locations
 let footer { footer; _ } = footer
 let okr_db t = t.okr_db
+let admin_dir t = t.admin_dir
 let gitlab_token t = t.gitlab_token
 
 let load file =

--- a/bin/conf.mli
+++ b/bin/conf.mli
@@ -20,6 +20,8 @@ type t
 val default : t
 (** A default configuration *)
 
+val teams : t -> Okra.Team.t list
+
 val projects : t -> Okra.Activity.project list
 (** A user's list of activer projects *)
 

--- a/bin/conf.mli
+++ b/bin/conf.mli
@@ -34,6 +34,10 @@ val footer : t -> string option
 val okr_db : t -> string option
 (** [okr_db] is the location of the OKR database. *)
 
+val admin_dir : t -> string option
+(** [admin_dir] is the location of the admin directory for the teams
+    subcommands. *)
+
 val gitlab_token : t -> string option
 (** [gitlab_token] is the optional Gitlab token, if present your Gitlab activity
     will also be queried. *)

--- a/bin/conf.mli
+++ b/bin/conf.mli
@@ -39,5 +39,5 @@ val gitlab_token : t -> string option
 val load : string -> (t, [ `Msg of string ]) result
 (** [load file] attempts to load a configuration from [file] *)
 
-val cmdliner : string Cmdliner.Term.t
-(** Cmdliner term for configuration file location *)
+val default_file_path : string
+(* [default_file_path] is the default file path of the Okra configuration. *)

--- a/bin/dune
+++ b/bin/dune
@@ -11,4 +11,5 @@
   fmt.cli
   logs.cli
   fmt.tty
-  dune-build-info))
+  dune-build-info
+  xdg))

--- a/bin/dune
+++ b/bin/dune
@@ -12,4 +12,6 @@
   logs.cli
   fmt.tty
   dune-build-info
-  xdg))
+  xdg)
+ (preprocess
+  (pps ppx_deriving_yaml)))

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -39,4 +39,4 @@ let () =
   exit
   @@ Cmd.eval
        (Cmd.group ~default:root_term root_info
-          [ Cat.cmd; Lint.cmd; Stats.cmd; Generate.cmd ])
+          [ Cat.cmd; Lint.cmd; Stats.cmd; Generate.cmd; Team.cmd ])

--- a/bin/team.ml
+++ b/bin/team.ml
@@ -1,0 +1,60 @@
+(*
+ * Copyright (c) 2022 Thibaut Mattio <thibaut.mattio@gmail.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+open Cmdliner
+
+let lint conf week_range admin_dir =
+  let admin_dir = Option.get admin_dir in
+  let week_range =
+    match week_range with
+    | Some weeks -> weeks
+    | None -> failwith "Need to specify week range."
+  in
+  let lhe, rhe =
+    match String.split_on_char '.' week_range with
+    | [ lhe; rhe ] -> (lhe, rhe)
+    | _ -> failwith "Couldn't decode week range."
+  in
+  let lhe = int_of_string lhe in
+  let rhe = int_of_string rhe in
+  let weeks = List.init (rhe - lhe + 1) (fun x -> lhe + x) in
+  let teams = Conf.teams conf in
+  let lint_report = Okra.Team.lint admin_dir weeks teams in
+  Format.printf "%a" Okra.Team.pp_lint_report lint_report
+
+(* Commands *)
+
+let lint_cmd =
+  let admin_dir =
+    let doc = "Path of the admin repository directory." in
+    Arg.(
+      value
+      & opt (some dir) (Some Filename.current_dir_name)
+      & info [ "C"; "admin-dir" ] ~docv:"ADMIN_DIR" ~doc)
+  in
+  let weeks =
+    let doc = "The week range to lint reports for." in
+    Arg.(
+      value & opt (some string) None & info [ "W"; "weeks" ] ~docv:"WEEKS" ~doc)
+  in
+  let doc = "Lint reports for a team." in
+  let info = Cmd.info "lint" ~doc in
+  Cmd.v info Term.(const lint $ Common.conf $ weeks $ admin_dir)
+
+let cmd =
+  let doc = "Work on multiple reports for a team" in
+  let info = Cmd.info "team" ~doc in
+  Cmd.group info [ lint_cmd ]

--- a/dune-project
+++ b/dune-project
@@ -39,6 +39,7 @@
   (fmt (>= 0.9.0))
   (lwt (>= 5.6.1))
   (tls (>= 0.17.0))
+  xdg
   get-activity
   (gitlab (>= 0.1.7))
   (calendar (>= 3.0.0))

--- a/dune-project
+++ b/dune-project
@@ -23,6 +23,7 @@
   (fmt (>= 0.9.0))
   (okra (= :version))
   (cmdliner (>= 1.1.1))
+  ppx_deriving_yaml
   bos
   dune-build-info
   (yaml (>= 3.0))

--- a/dune-project
+++ b/dune-project
@@ -23,7 +23,7 @@
   (fmt (>= 0.9.0))
   (okra (= :version))
   (cmdliner (>= 1.1.1))
-  ppx_deriving_yaml
+  (ppx_deriving_yaml (>= 0.2.0))
   bos
   dune-build-info
   (yaml (>= 3.0))

--- a/okra-bin.opam
+++ b/okra-bin.opam
@@ -16,7 +16,7 @@ depends: [
   "fmt" {>= "0.9.0"}
   "okra" {= version}
   "cmdliner" {>= "1.1.1"}
-  "ppx_deriving_yaml"
+  "ppx_deriving_yaml" {>= "0.2.0"}
   "bos"
   "dune-build-info"
   "yaml" {>= "3.0"}

--- a/okra-bin.opam
+++ b/okra-bin.opam
@@ -16,6 +16,7 @@ depends: [
   "fmt" {>= "0.9.0"}
   "okra" {= version}
   "cmdliner" {>= "1.1.1"}
+  "ppx_deriving_yaml"
   "bos"
   "dune-build-info"
   "yaml" {>= "3.0"}

--- a/okra.opam
+++ b/okra.opam
@@ -15,6 +15,7 @@ depends: [
   "fmt" {>= "0.9.0"}
   "lwt" {>= "5.6.1"}
   "tls" {>= "0.17.0"}
+  "xdg"
   "get-activity"
   "gitlab" {>= "0.1.7"}
   "calendar" {>= "3.0.0"}

--- a/src/lint.ml
+++ b/src/lint.ml
@@ -48,41 +48,39 @@ let fail_fmt_patterns =
 
 let pp_error ppf = function
   | Format_error x ->
-      List.iter (fun (pos, msg) -> Fmt.pf ppf "Line %d: %s\n" pos msg) x;
-      Fmt.pf ppf "%d formatting errors found. Parsing aborted.\n"
-        (List.length x)
+      let pp_msg ppf (pos, msg) = Fmt.pf ppf "Line %d: %s" pos msg in
+      Fmt.pf ppf "@[<v 0>%a@,%d formatting errors found. Parsing aborted.@]"
+        (Fmt.list ~sep:Fmt.sp pp_msg)
+        x (List.length x)
   | No_time_found (_, s) ->
       Fmt.pf ppf
-        "In KR %S:\n\
-        \  No time entry found. Each KR must be followed by '- @@... (x days)'\n"
+        "@[<hv 2>In KR %S:@ No time entry found. Each KR must be followed by \
+         '- @@... (x days)'@]@,"
         s
   | Invalid_time (_, s) ->
       Fmt.pf ppf
-        "In KR %S:\n\
-        \  Invalid time entry found. Format is '- @@eng1 (x days), @@eng2 (x \
-         days)'\n"
+        "@[<hv 2>In KR %S:@ Invalid time entry found. Format is '- @@eng1 (x \
+         days), @@eng2 (x days)'@]@,"
         s
   | Multiple_time_entries (_, s) ->
       Fmt.pf ppf
-        "In KR %S:\n\
-        \  Multiple time entries found. Only one time entry should follow \
-         immediately after the KR.\n"
+        "@[<hv 2>In KR %S:@ Multiple time entries found. Only one time entry \
+         should follow immediately after the KR.@]@,"
         s
   | No_work_found (_, s) ->
       Fmt.pf ppf
-        "In KR %S:\n\
-        \  No work items found. This may indicate an unreported parsing error. \
-         Remove the KR if it is without work.\n"
+        "@[<hv 2>In KR %S:@ No work items found. This may indicate an \
+         unreported parsing error. Remove the KR if it is without work.@]@,"
         s
   | No_KR_ID_found (_, s) ->
       Fmt.pf ppf
-        "In KR %S:\n\
-        \  No KR ID found. KRs should be in the format \"This is a KR \
-         (PLAT123)\", where PLAT123 is the KR ID. For KRs that don't have an \
-         ID yet, use \"New KR\" and for work without a KR use \"No KR\".\n"
+        "@[<hv 2>In KR %S:@ No KR ID found. KRs should be in the format \"This \
+         is a KR (PLAT123)\", where PLAT123 is the KR ID. For KRs that don't \
+         have an ID yet, use \"New KR\" and for work without a KR use \"No \
+         KR\".@]@,"
         s
   | No_project_found (_, s) ->
-      Fmt.pf ppf "In KR %S:\n  No project found (starting with '#')\n" s
+      Fmt.pf ppf "@[<hv 2>In KR %S:@ No project found (starting with '#')@]@," s
   | Not_all_includes s ->
       Fmt.pf ppf "Missing includes section: %a\n" Fmt.(list ~sep:comma string) s
 

--- a/src/lint.mli
+++ b/src/lint.mli
@@ -42,3 +42,4 @@ val lint_string_list :
 
 val string_of_error : lint_error -> string
 val short_messages_of_error : string -> lint_error -> string list
+val pp_error : Format.formatter -> lint_error -> unit

--- a/src/team.ml
+++ b/src/team.ml
@@ -45,7 +45,7 @@ let lint_member_week admin_dir member ~week ~year =
   match Sys.file_exists fname with
   | false -> Not_found fname
   | true -> (
-      let ic = In_channel.open_text fname in
+      let ic = open_in fname in
       match
         Lint.lint ~include_sections:[ "Last week" ] ~ignore_sections:[] ic
       with
@@ -88,6 +88,12 @@ let pp_lint_report ppf lint_report =
     (Fmt.list ~sep:(Fmt.any "@;<1 2>") pp_team_lint)
     lint_report
 
+let read_file f =
+  let ic = open_in f in
+  let s = really_input_string ic (in_channel_length ic) in
+  close_in ic;
+  s
+
 let aggregate ?okr_db admin_dir ~year ~week teams =
   let files =
     List.concat
@@ -106,7 +112,7 @@ let aggregate ?okr_db admin_dir ~year ~week teams =
          (fun file ->
            if not (Sys.file_exists file) then ""
            else
-             try In_channel.with_open_text file In_channel.input_all
+             try read_file file
              with Sys_error e ->
                Printf.eprintf
                  "An error ocurred while reading the input file(s).\n";

--- a/src/team.ml
+++ b/src/team.ml
@@ -80,7 +80,7 @@ let pp_lint_report ppf lint_report =
       member_lint
   in
   let pp_team_lint ppf (team, members_list) =
-    Fmt.pf ppf "=== %s === @;<1 2>%a" (name team)
+    Fmt.pf ppf "=== %s ===@;<1 2>%a" (name team)
       (Fmt.list ~sep:(Fmt.any "@;<1 2>") pp_member_lint)
       members_list
   in

--- a/src/team.ml
+++ b/src/team.ml
@@ -104,12 +104,14 @@ let aggregate ?okr_db admin_dir ~year ~week teams =
     String.concat "\n"
     @@ List.map
          (fun file ->
-           try In_channel.with_open_text file In_channel.input_all
-           with Sys_error e ->
-             Printf.eprintf
-               "An error ocurred while reading the input file(s).\n";
-             Printf.eprintf "Error: %s\n" e;
-             "")
+           if not (Sys.file_exists file) then ""
+           else
+             try In_channel.with_open_text file In_channel.input_all
+             with Sys_error e ->
+               Printf.eprintf
+                 "An error ocurred while reading the input file(s).\n";
+               Printf.eprintf "Error: %s\n" e;
+               "")
          files
   in
   let md = Omd.of_string content in

--- a/src/team.ml
+++ b/src/team.ml
@@ -1,0 +1,82 @@
+(*
+ * Copyright (c) 2022 Thibaut Mattio <thibaut.mattio@gmail.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+module Member = struct
+  type t = { name : string; github : string }
+
+  let make ~name ~github = { name; github }
+  let name { name; _ } = name
+  let github { github; _ } = github
+end
+
+type t = { name : string; members : Member.t list }
+
+let make ~name ~members = { name; members }
+let name { name; _ } = name
+let members { members; _ } = members
+
+type report = Not_found | Complete | Erroneous of Lint.lint_error
+type lint_report = (t * (Member.t * (int * report) list) list) list
+
+let lint_member_week admin_dir member week =
+  let fname =
+    Format.asprintf "%s/weekly/2022/%i/%s.md" admin_dir week
+      (Member.github member)
+  in
+  match Sys.file_exists fname with
+  | false -> Not_found
+  | true -> (
+      let ic = In_channel.open_text fname in
+      match
+        Lint.lint ~include_sections:[ "Last week" ] ~ignore_sections:[] ic
+      with
+      | Ok () -> Complete
+      | Error e -> Erroneous e)
+
+let lint_member admin_dir weeks member =
+  let lint_member_week = lint_member_week admin_dir member in
+  List.map (fun week -> (week, lint_member_week week)) weeks
+
+let lint_team admin_dir weeks members =
+  let lint_member = lint_member admin_dir weeks in
+  List.map (fun member -> (member, lint_member member)) members
+
+let lint admin_dir weeks teams =
+  let lint_team = lint_team admin_dir weeks in
+  List.map (fun team -> (team, lint_team (members team))) teams
+
+let pp_report ppf = function
+  | Not_found -> Fmt.pf ppf "Not found ❌"
+  | Complete -> Fmt.pf ppf "Complete ✅"
+  | Erroneous e -> Fmt.pf ppf "Lint error ⚠️@ @[<v 0>%a@]" Lint.pp_error e
+
+let pp_lint_report ppf lint_report =
+  let pp_report_lint ppf (week, report) =
+    Fmt.pf ppf "@[<hv 0>+ Report week %i: @[<v 0>%a@]@]" week pp_report report
+  in
+  let pp_member_lint ppf (member, member_lint) =
+    Fmt.pf ppf "+ %s@;<1 4>%a" (Member.name member)
+      (Fmt.list ~sep:(Fmt.any "@;<1 4>") pp_report_lint)
+      member_lint
+  in
+  let pp_team_lint ppf (team, members_list) =
+    Fmt.pf ppf "=== %s === @;<1 2>%a" (name team)
+      (Fmt.list ~sep:(Fmt.any "@;<1 2>") pp_member_lint)
+      members_list
+  in
+  Fmt.pf ppf "@[<v 0>%a@]@."
+    (Fmt.list ~sep:(Fmt.any "@;<1 2>") pp_team_lint)
+    lint_report

--- a/src/team.mli
+++ b/src/team.mli
@@ -1,0 +1,37 @@
+(*
+ * Copyright (c) 2022 Thibaut Mattio <thibaut.mattio@gmail.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+module Member : sig
+  type t
+
+  val make : name:string -> github:string -> t
+  val name : t -> string
+  val github : t -> string
+end
+
+type t
+
+val make : name:string -> members:Member.t list -> t
+val name : t -> string
+val members : t -> Member.t list
+
+type lint_report
+
+val lint : string -> int list -> t list -> lint_report
+(** [lint admin_dir weeks teams] generates a [lint_report] for the teams at the
+    given weeks. *)
+
+val pp_lint_report : Format.formatter -> lint_report -> unit

--- a/src/team.mli
+++ b/src/team.mli
@@ -30,11 +30,12 @@ val members : t -> Member.t list
 
 type lint_report
 
-val aggregate : ?okr_db:Masterdb.t -> string -> int -> t list -> Report.t
+val aggregate :
+  ?okr_db:Masterdb.t -> string -> year:int -> week:int -> t list -> Report.t
 (** [aggregate admin_dir week teams] aggregates the reports of the teams for the
     given week. *)
 
-val lint : string -> int list -> t list -> lint_report
+val lint : string -> year:int -> weeks:int list -> t list -> lint_report
 (** [lint admin_dir weeks teams] generates a [lint_report] for the teams at the
     given weeks. *)
 

--- a/src/team.mli
+++ b/src/team.mli
@@ -30,6 +30,10 @@ val members : t -> Member.t list
 
 type lint_report
 
+val aggregate : ?okr_db:Masterdb.t -> string -> int -> t list -> Report.t
+(** [aggregate admin_dir week teams] aggregates the reports of the teams for the
+    given week. *)
+
 val lint : string -> int list -> t list -> lint_report
 (** [lint admin_dir weeks teams] generates a [lint_report] for the teams at the
     given weeks. *)

--- a/test/bin/README.md
+++ b/test/bin/README.md
@@ -66,8 +66,8 @@ The configuration file for `okra` allows you to setup some default values and lo
 ```sh
 $ cat conf.simple.yaml
 projects:
-  - "Make Okra, the OKR management tool (OKR1)"
-  - "Make a web interface for Okra (OKR2)"
+  - title: "Make Okra, the OKR management tool (OKR1)"
+  - title: "Make a web interface for Okra (OKR2)"
 $ okra generate --week=37 --year=2021  --no-activity --conf=conf.simple.yaml
 <USERNAME> week 37: 2021/09/13 -- 2021/09/19
 
@@ -138,8 +138,8 @@ Sometimes you might have some recurring comments to make outside of last week's 
 ```sh
 $ cat conf.footer.yaml
 projects:
-  - "Make Okra, the OKR management tool (OKR1)"
-  - "Make a web interface for Okra (OKR2)"
+  - title: "Make Okra, the OKR management tool (OKR1)"
+  - title: "Make a web interface for Okra (OKR2)"
 footer: |
   # Meetings
   - A meeting with x, y and z

--- a/test/bin/files/conf.footer.yaml
+++ b/test/bin/files/conf.footer.yaml
@@ -1,6 +1,6 @@
 projects:
-  - "Make Okra, the OKR management tool (OKR1)"
-  - "Make a web interface for Okra (OKR2)"
+  - title: "Make Okra, the OKR management tool (OKR1)"
+  - title: "Make a web interface for Okra (OKR2)"
 footer: |
   # Meetings
   - A meeting with x, y and z

--- a/test/bin/files/conf.simple.yaml
+++ b/test/bin/files/conf.simple.yaml
@@ -1,3 +1,3 @@
 projects:
-  - "Make Okra, the OKR management tool (OKR1)"
-  - "Make a web interface for Okra (OKR2)"
+  - title: "Make Okra, the OKR management tool (OKR1)"
+  - title: "Make a web interface for Okra (OKR2)"

--- a/test/cram/lint/errors.t
+++ b/test/cram/lint/errors.t
@@ -23,8 +23,7 @@ No KR ID found:
   > EOF
   [ERROR(S)]: <stdin>
   
-  In KR "This is a KR":
-    No project found (starting with '#')
+  In KR "This is a KR": No project found (starting with '#')
   [1]
 
 No work items found:
@@ -217,8 +216,7 @@ Format errors
   $ okra lint err-no-project.md
   [ERROR(S)]: err-no-project.md
   
-  In KR "Everything is great":
-    No project found (starting with '#')
+  In KR "Everything is great": No project found (starting with '#')
   [1]
   $ okra lint --short err-no-project.md
   err-no-project.md:1:No project found for "Everything is great"

--- a/test/cram/team-lint.t/admin/weekly/2022/40/eng1.md
+++ b/test/cram/team-lint.t/admin/weekly/2022/40/eng1.md
@@ -1,0 +1,5 @@
+# Last Week
+
+- A KR (KR123)
+  - @eng1 (1 day)
+  - Work 1

--- a/test/cram/team-lint.t/admin/weekly/2022/41/eng1.md
+++ b/test/cram/team-lint.t/admin/weekly/2022/41/eng1.md
@@ -1,0 +1,5 @@
+# Last Week
+
+- A KR (KR123)
+  - @eng1 (1 day)
+  - Work 1

--- a/test/cram/team-lint.t/admin/weekly/2022/41/eng2.md
+++ b/test/cram/team-lint.t/admin/weekly/2022/41/eng2.md
@@ -1,0 +1,5 @@
+# Last Week
+
+- A KR (KR123)
+  + @eng1 (1 day)
+  + Work 1

--- a/test/cram/team-lint.t/conf.yml
+++ b/test/cram/team-lint.t/conf.yml
@@ -1,0 +1,7 @@
+teams:
+  - name: My Team
+    members:
+      - name: Engineer 1
+        github: eng1
+      - name: Engineer 2
+        github: eng2

--- a/test/cram/team-lint.t/dune
+++ b/test/cram/team-lint.t/dune
@@ -1,0 +1,1 @@
+(dirs admin)

--- a/test/cram/team-lint.t/run.t
+++ b/test/cram/team-lint.t/run.t
@@ -1,16 +1,16 @@
 
 Team Lint example
 
-  $ okra team lint -C admin/ -W 40.41 --conf ./conf.yml
-  === My Team === 
+  $ okra team lint -C admin/ -W 40.42 -Y 2022 --conf ./conf.yml
+  === My Team ===
     + Engineer 1
       + Report week 40: Complete ✅
       + Report week 41: Complete ✅
-      + Report week 42: Not found ❌
+      + Report week 42: Not found: admin//weekly/2022/42/eng1.md ❌
     + Engineer 2
-      + Report week 40: Not found ❌
-      + Report week 41: Lint error ⚠️
+      + Report week 40: Not found: admin//weekly/2022/40/eng2.md ❌
+      + Report week 41: Lint error at admin//weekly/2022/41/eng2.md ⚠️
                         Line 4: + used as bullet point, this can confuse the parser. Only use - as bullet marker.
                         Line 5: + used as bullet point, this can confuse the parser. Only use - as bullet marker.
                         2 formatting errors found. Parsing aborted.
-      + Report week 42: Not found ❌
+      + Report week 42: Not found: admin//weekly/2022/42/eng2.md ❌

--- a/test/cram/team-lint.t/run.t
+++ b/test/cram/team-lint.t/run.t
@@ -1,0 +1,16 @@
+
+Team Lint example
+
+  $ okra team lint -C admin/ -W 40.41 --conf ./conf.yml
+  === My Team === 
+    + Engineer 1
+      + Report week 40: Complete ✅
+      + Report week 41: Complete ✅
+      + Report week 42: Not found ❌
+    + Engineer 2
+      + Report week 40: Not found ❌
+      + Report week 41: Lint error ⚠️
+                        Line 4: + used as bullet point, this can confuse the parser. Only use - as bullet marker.
+                        Line 5: + used as bullet point, this can confuse the parser. Only use - as bullet marker.
+                        2 formatting errors found. Parsing aborted.
+      + Report week 42: Not found ❌


### PR DESCRIPTION
Add a new command to lint the reports of a team.

The list of teams and their members can be added to the configuration, and the command generates a report with the following format:

```
=== Team Name === 
  + Team Member 1
    + Report week 39: Complete ✅
    + Report week 40: Complete ✅
    + Report week 41: Complete ✅
    + Report week 42: Not found ❌
    + Report week 43: Not found ❌
    + Report week 44: Not found ❌
  + Team Member 2
    + Report week 39: Complete ✅
    + Report week 40: Lint error ⚠️
                      Line 10: + used as bullet point, this can confuse the parser. Only use - as bullet marker.
                      Line 11: + used as bullet point, this can confuse the parser. Only use - as bullet marker.
                      Line 12: + used as bullet point, this can confuse the parser. Only use - as bullet marker.
                      Line 13: + used as bullet point, this can confuse the parser. Only use - as bullet marker.
                      4 formatting errors found. Parsing aborted.
    + Report week 41: Lint error ⚠️
                      Line 6: + used as bullet point, this can confuse the parser. Only use - as bullet marker.
                      Line 7: + used as bullet point, this can confuse the parser. Only use - as bullet marker.
                      Line 8: + used as bullet point, this can confuse the parser. Only use - as bullet marker.
                      Line 12: + used as bullet point, this can confuse the parser. Only use - as bullet marker.
                      Line 13: + used as bullet point, this can confuse the parser. Only use - as bullet marker.
                      5 formatting errors found. Parsing aborted.
    + Report week 42: Not found ❌
    + Report week 43: Not found ❌
    + Report week 44: Not found ❌
```

**TODO**

- Need to check that the pprint boxes didn't break the normal lint command