### PR TITLE
Add support for Work Items without KR prefix

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,5 +6,6 @@
 - Update cmdliner (#103, @tmcgilchrist)
 - Update gitlab (#100, @tmcgilchrist)
 - Add --version option (#99, @magnuss)
+- Add support for pound prefixed KRs, aka Work Items (#124, @rikusilvola)
 
 (changes before Jan '22 not tracked)

--- a/src/lint.ml
+++ b/src/lint.ml
@@ -74,8 +74,9 @@ let pp_error ppf = function
         s
   | No_KR_ID_found (_, s) ->
       Fmt.pf ppf
-        "@[<hv 2>In KR %S:@ No KR ID found. KRs should be in the format \"This \
-         is a KR (PLAT123)\", where PLAT123 is the KR ID. For KRs that don't \
+        "@[<hv 2>In KR %S:@ No KR ID found. WIs should be in the format \"This \
+         is a WI (#123)\", where 123 is the WI issue ID. Legacy KRs should be \
+         in the format \"This is a KR (PLAT123)\", where PLAT123 is the KR ID. \
          have an ID yet, use \"New KR\" and for work without a KR use \"No \
          KR\".@]@,"
         s

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -42,8 +42,9 @@ type t =
 
 type markdown = (string * string) list Omd.block list
 
-let okr_re = Str.regexp "\\(.+\\) (\\([a-zA-Z]+[0-9]+\\))$"
-(* Header: This is a KR (KR12) *)
+let okr_re = Str.regexp "\\(.+\\) (\\([a-zA-Z#]+[0-9]+\\))$"
+(* Header: This is a legacy KR (KR12) *)
+(* Header: This is a GitHub WI (12) *)
 
 let obj_re = Str.regexp "\\(.+\\) (\\([a-zA-Z ]+\\))$"
 (* Header: This is an objective (Tech lead name) *)

--- a/test/aggregate/valid-time1.acc
+++ b/test/aggregate/valid-time1.acc
@@ -2,6 +2,10 @@
 
 ## Objective
 
+- This is a WI (#123)
+  - @eng6 (1 day)
+  - My work
+
 - This is a KR (KR123)
   - @eng1 (.5 day)
   - My work

--- a/test/cram/lint/engineer.t
+++ b/test/cram/lint/engineer.t
@@ -8,10 +8,15 @@ This is a valid one:
   > 
   > - Project1 (KR1)
   > - Project2 (KR2)
+  > - Project3 (#3)
   > 
   > This is not formatted.
   > 
   > # Last week
+  > 
+  > - This is a WI (#123)
+  >   - @eng1 (1 day)
+  >   - My work
   > 
   > - This is a KR (KR123)
   >   - @eng1 (1 day)
@@ -80,5 +85,5 @@ Only "No KR" and "New KR" are supported for KR's without identifiers
   [ERROR(S)]: <stdin>
   
   In KR "This is a KR (Off KR)":
-    No KR ID found. KRs should be in the format "This is a KR (PLAT123)", where PLAT123 is the KR ID. For KRs that don't have an ID yet, use "New KR" and for work without a KR use "No KR".
+    No KR ID found. WIs should be in the format "This is a WI (#123)", where 123 is the WI issue ID. Legacy KRs should be in the format "This is a KR (PLAT123)", where PLAT123 is the KR ID. have an ID yet, use "New KR" and for work without a KR use "No KR".
   [1]

--- a/test/cram/lint/errors.t
+++ b/test/cram/lint/errors.t
@@ -13,7 +13,7 @@ No KR ID found:
   [ERROR(S)]: <stdin>
   
   In KR "This is a KR":
-    No KR ID found. KRs should be in the format "This is a KR (PLAT123)", where PLAT123 is the KR ID. For KRs that don't have an ID yet, use "New KR" and for work without a KR use "No KR".
+    No KR ID found. WIs should be in the format "This is a WI (#123)", where 123 is the WI issue ID. Legacy KRs should be in the format "This is a KR (PLAT123)", where PLAT123 is the KR ID. have an ID yet, use "New KR" and for work without a KR use "No KR".
   [1]
 
   $ okra lint << EOF
@@ -202,7 +202,7 @@ Format errors
   [ERROR(S)]: err-no-kr-id.md
   
   In KR "Everything is great":
-    No KR ID found. KRs should be in the format "This is a KR (PLAT123)", where PLAT123 is the KR ID. For KRs that don't have an ID yet, use "New KR" and for work without a KR use "No KR".
+    No KR ID found. WIs should be in the format "This is a WI (#123)", where 123 is the WI issue ID. Legacy KRs should be in the format "This is a KR (PLAT123)", where PLAT123 is the KR ID. have an ID yet, use "New KR" and for work without a KR use "No KR".
   [1]
   $ okra lint --short err-no-kr-id.md
   err-no-kr-id.md:3:No KR ID found for "Everything is great"

--- a/test/cram/lint/team.t
+++ b/test/cram/lint/team.t
@@ -35,6 +35,14 @@ Examples of valid ones:
   >   - More work
   > EOF
   [OK]: <stdin>
+  $ okra lint --team << EOF
+  > # This is a title
+  > 
+  > - This is a WI (#123)
+  >   - @eng1 (1 day)
+  >   - My work
+  > EOF
+  [OK]: <stdin>
 
 Errors are not ignored outside the ignored section
 

--- a/test/reports/work_item.acc
+++ b/test/reports/work_item.acc
@@ -1,0 +1,7 @@
+# Title
+
+## Project
+
+- This is a Work Item (#123)
+  - @eng1 (1 day)
+  - work

--- a/test/test_aggregate.ml
+++ b/test/test_aggregate.ml
@@ -31,7 +31,8 @@ let test_time_parsing f () =
   Alcotest.(check (float 0.0)) "eng1 time" 3.0 (Hashtbl.find res "eng1");
   Alcotest.(check (float 0.0)) "eng3 time" 5.0 (Hashtbl.find res "eng3");
   Alcotest.(check (float 0.0)) "eng4 time" 1.5 (Hashtbl.find res "eng4");
-  Alcotest.(check (float 0.0)) "eng5 time" 11.0 (Hashtbl.find res "eng5")
+  Alcotest.(check (float 0.0)) "eng5 time" 11.0 (Hashtbl.find res "eng5");
+  Alcotest.(check (float 0.0)) "eng6 time" 1.0 (Hashtbl.find res "eng6")
 
 let tests =
   [

--- a/test/test_reports.ml
+++ b/test/test_reports.ml
@@ -53,9 +53,16 @@ let test_kr_agg1 () =
   (* also check that time adds up *)
   Alcotest.(check (float 0.0)) "eng1 time" 4.0 (Hashtbl.find res "eng1")
 
+let test_work_item () =
+  let res = aggregate "./reports/work_item.acc" in
+  Alcotest.(check bool) "#123 exists" true (contains_kr res (ID "#123"));
+  let res = Okra.Aggregate.by_engineer res in
+  Alcotest.(check (float 0.0)) "eng1 time" 1.0 (Hashtbl.find res "eng1")
+
 let tests =
   [
     ("Test_kr_aggregation", `Quick, test_kr_agg1);
     ("Test_newkr_exists", `Quick, test_newkr_exists1);
     ("Test_newkr_replaced", `Quick, test_newkr_replaced1);
+    ("Test_work_item", `Quick, test_work_item);
   ]


### PR DESCRIPTION
New Work Items are prefixed with a pound character (Plat123) vs (#123). Linting these correctly requires updating the regular expression slightly.