### PR TITLE
Update install instructions to pin main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Each command is described in more detail below.
 With opam (remove existing okra-related pins first):
 
 ```
-$ opam pin -y https://github.com/MagnusS/okra.git#release
+$ opam pin -y https://github.com/MagnusS/okra.git#main
 ```
 
 This should install two packages; `okra` and `okra-bin`. Note that `okra-bin` is required to have the `okra` command in path.


### PR DESCRIPTION
The release branch hasn't been updated in a while and recent changes to okra are needed to parse weekly reports with WIs in them. This changes the install instructions to pin the main branch so users get access to these features when installing okra according to the instructions in the readme.