### PR TITLE
fix logic in with_links

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -402,7 +402,7 @@ let include_sections t = t.includes.include_sections
 let ignore_sections t = t.includes.ignore_sections
 let with_days t = t.printconf.days
 let with_names t = t.printconf.names
-let with_links t = not t.printconf.links
+let with_links t = t.printconf.links
 let with_description t = t.printconf.descriptions
 let conf t = t.conf
 


### PR DESCRIPTION
`with_links` corresponds to `links`, not to its opposite (the value of the `--no-links` options has already been switched).

This logic issue has made `--no-links` the default by mistake.
